### PR TITLE
Fix pvlib version in order to create conda build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
             - v1-dep-{{ .Branch }}-
             - v1-dep-master-
             - v1-dep-
-      - run: sudo pip install pytest==3.2.2 numpy==1.13.3 scipy==0.19.1 pandas==0.23.3 shapely==1.6.1 pvlib==0.6.1b0 future==0.16.0 six==1.11.0 pytest-mock==1.10.0
+      - run: sudo pip install pytest==3.2.2 numpy==1.13.3 scipy==0.19.1 pandas==0.23.3 shapely==1.6.1 pvlib==0.6.0 future==0.16.0 six==1.11.0 pytest-mock==1.10.0
       - save_cache:
           key: v1-dep-{{ .Branch }}-{{ epoch }}
           paths:

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ INSTALL_REQUIRES = ['numpy>=1.13.1',
                     'scipy>=0.19.1',
                     'pandas>=0.23.3',
                     'shapely>=1.6.1',
-                    'pvlib>=0.6.1b0',
+                    'pvlib>=0.6.0',
                     'matplotlib>=2.1.0',
                     'future>=0.16.0',
                     'six>=1.11.0']


### PR DESCRIPTION
Conda build currently fails because of requirement: ``pvlib >= 0.6.1b0``, which cannot currently be satisfied in conda. Fortunately everything should work with ``pvlib >= 0.6.0``.