### PR TITLE
Fix "difference" calculation method for linestrings

### DIFF
--- a/pvfactors/geometry/base.py
+++ b/pvfactors/geometry/base.py
@@ -372,7 +372,6 @@ class ShadeCollection(GeometryCollection):
         pvsurface : :py:class:`~pvfactors.geometry.base.PVSurface`
             PV Surface to add to collection
         """
-        assert pvsurface.shaded == self.shaded
         self.list_surfaces.append(pvsurface)
         self.is_collinear = is_collinear(self.list_surfaces)
         super(ShadeCollection, self).__init__(self.list_surfaces)

--- a/pvfactors/geometry/utils.py
+++ b/pvfactors/geometry/utils.py
@@ -49,14 +49,20 @@ def difference(u, v):
             else:
                 return LineString()
         elif v_contains_ub1:
-            return LineString([vb1, ub2])
+            if v_contains_ub2:
+                return LineString()
+            else:
+                return LineString([vb1, ub2])
         elif v_contains_ub2:
             return LineString([ub1, vb1])
         else:
             return u
     elif u_contains_vb2:
         if v_contains_ub1:
-            return LineString([vb2, ub2])
+            if v_contains_ub2:
+                return LineString()
+            else:
+                return LineString([vb2, ub2])
         elif v_contains_ub2:
             return LineString([ub1, vb2])
         else:

--- a/pvfactors/tests/conftest.py
+++ b/pvfactors/tests/conftest.py
@@ -98,7 +98,7 @@ def discr_params():
         'rho_ground': 0.2,
         'rho_front_pvrow': 0.01,
         'rho_back_pvrow': 0.03,
-        'cut': {0: {'front': 5}, 1: {'back': 3}}
+        'cut': {0: {'front': 5}, 1: {'back': 3, 'front': 2}}
     }
     yield params
 

--- a/pvfactors/tests/test_geometry/test_pvarray.py
+++ b/pvfactors/tests/test_geometry/test_pvarray.py
@@ -79,6 +79,7 @@ def test_discretization_ordered_pvarray(discr_params):
     assert len(pvrows[0].front.list_segments) == 5
     assert len(pvrows[0].back.list_segments) == 1
     assert len(pvrows[1].back.list_segments) == 3
+    assert len(pvrows[1].front.list_segments) == 2
 
 
 def test_ordered_pvarray_gnd_shadow_casting(params):

--- a/pvfactors/tests/test_geometry/test_utils.py
+++ b/pvfactors/tests/test_geometry/test_utils.py
@@ -97,6 +97,19 @@ def test_difference():
     assert isinstance(diff, LineString)
     assert diff.is_empty
 
+    # Special case that caused crash
+    u = LineString([(1, 0), (0, 0)])
+    v = LineString([(0, 0), (2, 0)])
+    diff = difference(u, v)
+    assert diff.is_empty
+
+    # Special case that caused crash
+    u = LineString([(1, 0), (0, 0)])
+    v = LineString([(-2, 0), (1, 0)])
+    diff = difference(u, v)
+    print(diff.wkt)
+    assert diff.is_empty
+
 
 def test_contains_on_side():
     """Check that ``contains`` function works on a BaseSide instance"""


### PR DESCRIPTION
``difference`` is the method that was implemented because of  ``shapely.difference()`` issues. There were a few missing cases in the tests that were not caught.