### PR TITLE
Update circleci to test in python 3.5 and 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,9 @@ workflows:
   test:
     jobs:
       - test-python-2.7
+      - test-python-3.5
       - test-python-3.6
+      - test-python-3.7
 jobs:
   test-python-2.7: &test-template
     working_directory: ~/SunPower/pvfactors
@@ -42,7 +44,15 @@ jobs:
           path: /tmp/circleci-artifacts
       - store_artifacts:
           path: /tmp/circleci-test-results
+  test-python-3.5:
+    <<: *test-template
+    docker:
+      - image: circleci/python:3.5.7-stretch
   test-python-3.6:
     <<: *test-template
     docker:
       - image: circleci/python:3.6.6-stretch
+  test-python-3.7:
+    <<: *test-template
+    docker:
+      - image: circleci/python:3.7.3-stretch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
             - v1-dep-{{ .Branch }}-
             - v1-dep-master-
             - v1-dep-
-      - run: sudo pip install pytest numpy scipy pandas shapely pvlib future six pytest-mock tqdm
+      - run: sudo pip install pytest scipy shapely pvlib future six pytest-mock tqdm
       - save_cache:
           key: v1-dep-{{ .Branch }}-{{ epoch }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
             - v1-dep-{{ .Branch }}-
             - v1-dep-master-
             - v1-dep-
-      - run: sudo pip install pytest==3.2.2 numpy==1.13.3 scipy==0.19.1 pandas==0.23.3 shapely==1.6.4.post2 pvlib==0.6.0 future==0.16.0 six==1.11.0 pytest-mock==1.10.0 tqdm
+      - run: sudo pip install pytest numpy scipy pandas shapely pvlib future six pytest-mock tqdm
       - save_cache:
           key: v1-dep-{{ .Branch }}-{{ epoch }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
             - v1-dep-{{ .Branch }}-
             - v1-dep-master-
             - v1-dep-
-      - run: sudo pip install pytest==3.2.2 numpy==1.13.3 scipy==0.19.1 pandas==0.23.3 shapely==1.6.1 pvlib==0.6.0 future==0.16.0 six==1.11.0 pytest-mock==1.10.0 tqdm
+      - run: sudo pip install pytest==3.2.2 numpy==1.13.3 scipy==0.19.1 pandas==0.23.3 shapely==1.6.4.post2 pvlib==0.6.0 future==0.16.0 six==1.11.0 pytest-mock==1.10.0 tqdm
       - save_cache:
           key: v1-dep-{{ .Branch }}-{{ epoch }}
           paths:

--- a/pvfactors/tests/conftest.py
+++ b/pvfactors/tests/conftest.py
@@ -206,5 +206,5 @@ def df_inputs_clearsky_8760():
     fp = os.path.join(DIR_TEST_DATA,
                       'file_test_inputs_MET_clearsky_tucson.csv')
     df = pd.read_csv(fp, index_col=0)
-    df.index = pd.DatetimeIndex(df.index).tz_localize('UTC').tz_convert(tz)
+    df.index = pd.DatetimeIndex(df.index).tz_convert(tz)
     yield df

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-numpy>=1.13.1
+numpy>=1.10.1
 scipy>=0.19.1
-pandas>=0.23.3
+pandas>=0.14.0
 shapely>=1.6.4.post2
 pvlib>=0.6.0
-matplotlib>=2.1.0
-future>=0.16.0
-six>=1.11.0
+matplotlib
+future
+six
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.13.1
 scipy>=0.19.1
 pandas>=0.23.3
-shapely>=1.6.1
+shapely>=1.6.4.post2
 pvlib>=0.6.0
 matplotlib>=2.1.0
 future>=0.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
-numpy>=1.10.1
-scipy>=0.19.1
-pandas>=0.14.0
-shapely>=1.6.4.post2
 pvlib>=0.6.0
+scipy>=0.19.1
+shapely>=1.6.4.post2
 matplotlib
 future
 six

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,9 @@ CLASSIFIERS = [
     'Intended Audience :: Science/Research',
     'Programming Language :: Python',
     'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
     'Topic :: Scientific/Engineering',
 ]
 


### PR DESCRIPTION
- See #49: the python versions supported and tested in pvfactors are consistent, but since ``pvlib`` runs tests in python 3.5 and 3.7 with ``pvfactors``, this should be reflected in the ``pvfactors`` tests as well.
- Simplify dependency versions in ``requirements.txt`` and circleci: now the ``pvlib`` version installed will dictate which ``numpy`` and ``pandas`` versions to use
