### PR TITLE
Added a Tolerance for direct shading detection to cast_shadow function

### DIFF
--- a/pvfactors/geometry/pvarray.py
+++ b/pvfactors/geometry/pvarray.py
@@ -130,7 +130,7 @@ class OrderedPVArray(BasePVArray):
         """Use calculated solar_2d_vector and array configuration to calculate
         shadows being casted in the ordered pv array.
         The logic here is quite specific to ordered pv arrays"""
-        tol=1e-5
+        tol=1e-6
         self.illum_side = ('front' if self.pvrows[0].front.n_vector.dot(
             self.solar_2d_vector) >= 0 else 'back')
         last_gnd_2 = None

--- a/pvfactors/geometry/pvarray.py
+++ b/pvfactors/geometry/pvarray.py
@@ -153,7 +153,6 @@ class OrderedPVArray(BasePVArray):
                    and not stop_checking_for_direct_shading:
                     # There's inter-row shading if ground shadows overlap
                     if self.illum_side == 'front':
-                        # print(f'has direct shading:{gnd_1.x - last_gnd_2.x}')
                         self.has_direct_shading = gnd_1.x + tol < last_gnd_2.x 
                     else:
                         self.has_direct_shading = gnd_2.x + tol < last_gnd_1.x

--- a/pvfactors/geometry/pvarray.py
+++ b/pvfactors/geometry/pvarray.py
@@ -4,7 +4,7 @@ geometries."""
 import numpy as np
 from pvfactors.geometry.pvground import PVGround
 from pvfactors.geometry.pvrow import PVRow
-from pvfactors.config import X_ORIGIN_PVROWS, VIEW_DICT
+from pvfactors.config import X_ORIGIN_PVROWS, VIEW_DICT, DISTANCE_TOLERANCE
 from pvfactors.geometry.base import get_solar_2d_vector, BasePVArray
 from pvfactors.geometry.utils import projection
 from shapely.geometry import LineString, Point
@@ -130,7 +130,6 @@ class OrderedPVArray(BasePVArray):
         """Use calculated solar_2d_vector and array configuration to calculate
         shadows being casted in the ordered pv array.
         The logic here is quite specific to ordered pv arrays"""
-        tol=1e-6
         self.illum_side = ('front' if self.pvrows[0].front.n_vector.dot(
             self.solar_2d_vector) >= 0 else 'back')
         last_gnd_2 = None
@@ -153,9 +152,9 @@ class OrderedPVArray(BasePVArray):
                    and not stop_checking_for_direct_shading:
                     # There's inter-row shading if ground shadows overlap
                     if self.illum_side == 'front':
-                        self.has_direct_shading = gnd_1.x + tol < last_gnd_2.x 
+                        self.has_direct_shading = gnd_1.x + DISTANCE_TOLERANCE < last_gnd_2.x 
                     else:
-                        self.has_direct_shading = gnd_2.x + tol < last_gnd_1.x
+                        self.has_direct_shading = gnd_2.x + DISTANCE_TOLERANCE < last_gnd_1.x
                     stop_checking_for_direct_shading = True
                 last_gnd_2 = gnd_2
                 last_gnd_1 = gnd_1

--- a/pvfactors/geometry/pvarray.py
+++ b/pvfactors/geometry/pvarray.py
@@ -130,6 +130,7 @@ class OrderedPVArray(BasePVArray):
         """Use calculated solar_2d_vector and array configuration to calculate
         shadows being casted in the ordered pv array.
         The logic here is quite specific to ordered pv arrays"""
+        tol=1e-5
         self.illum_side = ('front' if self.pvrows[0].front.n_vector.dot(
             self.solar_2d_vector) >= 0 else 'back')
         last_gnd_2 = None
@@ -152,9 +153,10 @@ class OrderedPVArray(BasePVArray):
                    and not stop_checking_for_direct_shading:
                     # There's inter-row shading if ground shadows overlap
                     if self.illum_side == 'front':
-                        self.has_direct_shading = gnd_1.x < last_gnd_2.x
+                        # print(f'has direct shading:{gnd_1.x - last_gnd_2.x}')
+                        self.has_direct_shading = gnd_1.x + tol < last_gnd_2.x 
                     else:
-                        self.has_direct_shading = gnd_2.x < last_gnd_1.x
+                        self.has_direct_shading = gnd_2.x + tol < last_gnd_1.x
                     stop_checking_for_direct_shading = True
                 last_gnd_2 = gnd_2
                 last_gnd_1 = gnd_1

--- a/pvfactors/tests/test_geometry/test_pvarray.py
+++ b/pvfactors/tests/test_geometry/test_pvarray.py
@@ -497,3 +497,16 @@ def test_time_ordered_pvarray(params):
         list_elapsed.append(toc - tic)
 
     print("\nAvg time elapsed: {} s".format(np.mean(list_elapsed)))
+
+def test_ordered_pvarray_gnd_shadow_casting_tolerance():
+    params = {'axis_azimuth': 0, 
+            'gcr': 0.3,
+            'n_pvrows': 3,
+            'pvrow_height': 1.8,
+            'pvrow_width': 1.98,
+            'solar_azimuth': 263.99310644558074,
+            'solar_zenith': 73.91658668648401, 
+            'surface_azimuth': 270.0, 
+            'surface_tilt': 51.98206680806641}
+    pvarray_w_direct_shading = OrderedPVArray.from_dict(params)
+    pvarray_w_direct_shading.cast_shadows()


### PR DESCRIPTION
Simple PR to add a tolerance to the detection of direct shading.
If the shading is very small, the projection function will return an empty GeometryCollection and `cast_shadow` will fail.
Probably the tolerance value is not definitive.