### PR TITLE
Pass irradiance params to run functions

### DIFF
--- a/pvfactors/run.py
+++ b/pvfactors/run.py
@@ -22,7 +22,8 @@ def run_timeseries_engine(fn_build_report, pvarray_parameters,
                           cls_pvarray=OrderedPVArray, cls_engine=PVEngine,
                           cls_irradiance=HybridPerezOrdered,
                           cls_vf=VFCalculator,
-                          fast_mode_pvrow_index=None):
+                          fast_mode_pvrow_index=None,
+                          irradiance_model_params={}):
     """Run timeseries simulation in normal mode, and using the specified
     classes.
 
@@ -67,6 +68,9 @@ def run_timeseries_engine(fn_build_report, pvarray_parameters,
         If a valid pvrow index is passed, then the PVEngine fast mode
         will be activated and the engine calculation will be done only
         for the back surface of the selected pvrow (Default = None)
+    irradiance_model_params : dict, optional
+        Dictionary of parameters that will be passed to the irradiance model
+        class as kwargs at instantiation (Default = {})
 
     Returns
     -------
@@ -76,7 +80,7 @@ def run_timeseries_engine(fn_build_report, pvarray_parameters,
     """
 
     # Instantiate classes and engine
-    irradiance_model = cls_irradiance()
+    irradiance_model = cls_irradiance(**irradiance_model_params)
     vf_calculator = cls_vf()
     eng = cls_engine(pvarray_parameters, cls_pvarray=cls_pvarray,
                      irradiance_model=irradiance_model,
@@ -99,7 +103,7 @@ def run_parallel_engine(report_builder, pvarray_parameters,
                         cls_pvarray=OrderedPVArray, cls_engine=PVEngine,
                         cls_irradiance=HybridPerezOrdered,
                         cls_vf=VFCalculator, fast_mode_pvrow_index=None,
-                        n_processes=2):
+                        irradiance_model_params={}, n_processes=2):
     """Run timeseries simulation using multiprocessing. Here, instead of a
     function that will build the report, the users will need to pass a class
     (or an object).
@@ -146,6 +150,9 @@ def run_parallel_engine(report_builder, pvarray_parameters,
         If a valid pvrow index is passed, then the PVEngine fast mode
         will be activated and the engine calculation will be done only
         for the back surface of the selected pvrow (Default = None)
+    irradiance_model_params : dict, optional
+        Dictionary of parameters that will be passed to the irradiance model
+        class as kwargs at instantiation (Default = {})
     n_processes : int, optional
         Number of parallel processes to run for the calculation (Default = 2)
 
@@ -181,6 +188,7 @@ def run_parallel_engine(report_builder, pvarray_parameters,
     folds_cls_irradiance = [cls_irradiance] * n_processes
     folds_cls_vf = [cls_vf] * n_processes
     folds_fast_mode_pvrow_index = [fast_mode_pvrow_index] * n_processes
+    folds_irradiance_model_params = [irradiance_model_params] * n_processes
     report_indices = list(range(n_processes))
 
     # Zip all the folds together
@@ -189,7 +197,8 @@ def run_parallel_engine(report_builder, pvarray_parameters,
                        folds_solar_azimuth, folds_surface_tilt,
                        folds_surface_azimuth, folds_albedo, folds_cls_pvarray,
                        folds_cls_engine, folds_cls_irradiance, folds_cls_vf,
-                       folds_fast_mode_pvrow_index, report_indices))
+                       folds_fast_mode_pvrow_index,
+                       folds_irradiance_model_params, report_indices))
 
     # Start multiprocessing
     pool = Pool(n_processes)
@@ -231,7 +240,7 @@ def _run_serially(args):
     report_builder, pvarray_parameters, timestamps, dni, dhi, \
         solar_zenith, solar_azimuth, surface_tilt, surface_azimuth,\
         albedo, cls_pvarray, cls_engine, cls_irradiance, cls_vf, \
-        fast_mode_pvrow_index, idx = args
+        fast_mode_pvrow_index, irradiance_model_params, idx = args
 
     report = run_timeseries_engine(
         report_builder.build, pvarray_parameters,
@@ -239,6 +248,7 @@ def _run_serially(args):
         surface_tilt, surface_azimuth, albedo,
         cls_pvarray=cls_pvarray, cls_engine=cls_engine,
         cls_irradiance=cls_irradiance, cls_vf=cls_vf,
-        fast_mode_pvrow_index=fast_mode_pvrow_index)
+        fast_mode_pvrow_index=fast_mode_pvrow_index,
+        irradiance_model_params=irradiance_model_params)
 
     return report, idx

--- a/pvfactors/tests/test_run.py
+++ b/pvfactors/tests/test_run.py
@@ -1,3 +1,4 @@
+from pvfactors.run import run_timeseries_engine, run_parallel_engine
 from pvfactors.report import ExampleReportBuilder
 import numpy as np
 import pytest
@@ -7,7 +8,6 @@ import mock
 def test_run_timeseries_engine(fn_report_example, params_serial,
                                df_inputs_clearsky_8760):
 
-    from pvfactors.run import run_timeseries_engine
     df_inputs = df_inputs_clearsky_8760.iloc[:24, :]
     n = df_inputs.shape[0]
 
@@ -38,10 +38,28 @@ def test_run_timeseries_engine(fn_report_example, params_serial,
                                    8.642850754173368)
 
 
-def test_run_parallel_engine(params_serial,
-                             df_inputs_clearsky_8760):
+def test_params_irradiance_model():
+    """Test that irradiance params are passed correctly in
+    run_timeseries_engine"""
+    mock_irradiance_model = mock.MagicMock()
+    mock_engine = mock.MagicMock()
+    irradiance_params = {'horizon_band_angle': 15.}
 
-    from pvfactors.run import run_parallel_engine
+    _ = run_timeseries_engine(
+        None, None,
+        None, None, None, None, None, None,
+        None, None, cls_engine=mock_engine,
+        cls_irradiance=mock_irradiance_model,
+        irradiance_model_params=irradiance_params)
+
+    mock_irradiance_model.assert_called_once_with(
+        horizon_band_angle=irradiance_params['horizon_band_angle'])
+
+
+def test_run_parallel_engine_with_irradiance_params(params_serial,
+                                                    df_inputs_clearsky_8760):
+    """Test that irradiance model params are passed correctly in parallel
+    simulations"""
     df_inputs = df_inputs_clearsky_8760.iloc[:24, :]
     n = df_inputs.shape[0]
 
@@ -53,67 +71,25 @@ def test_run_parallel_engine(params_serial,
     solar_azimuth = df_inputs.solar_azimuth.values
     surface_tilt = df_inputs.surface_tilt.values
     surface_azimuth = df_inputs.surface_azimuth.values
-
     n_processes = 2
-    report = run_parallel_engine(
+
+    irradiance_params = {'horizon_band_angle': 6.5}
+    report_no_params = run_parallel_engine(
         ExampleReportBuilder, params_serial,
         timestamps, dni, dhi, solar_zenith, solar_azimuth, surface_tilt,
-        surface_azimuth, params_serial['rho_ground'], n_processes=n_processes)
-
-    assert len(report['qinc_front']) == n
-    # Test value consistency: not sure exactly why value is not exactly equal
-    # to one in serial test, but difference not significant
-    np.testing.assert_almost_equal(np.nansum(report['qinc_back']),
-                                   541.7115807694377)
-    np.testing.assert_almost_equal(np.nansum(report['iso_back']),
-                                   18.050083142438311)
-    # Check that the reports were sorted correctly
-    np.testing.assert_almost_equal(report['qinc_back'][7],
-                                   11.160301350847325)
-    np.testing.assert_almost_equal(report['qinc_back'][-8],
-                                   8.642850754173368)
-
-
-@pytest.fixture(scope='function')
-def mock_pool(mocker):
-    yield mocker.patch('multiprocessing.Pool')
-
-
-def test_params_irradiance_model(mock_pool):
-    """Test that irradiance params are passed correctly in
-    run_timeseries_engine and run_parallel_calculations"""
-    mock_irradiance_model = mock.MagicMock()
-    mock_engine = mock.MagicMock()
-    irradiance_params = {'horizon_band_angle': 15.}
-
-    from pvfactors.run import run_timeseries_engine, run_parallel_engine
-    _ = run_timeseries_engine(
-        None, None,
-        None, None, None, None, None, None,
-        None, None, cls_engine=mock_engine,
-        cls_irradiance=mock_irradiance_model,
+        surface_azimuth, params_serial['rho_ground'], n_processes=n_processes,
         irradiance_model_params=irradiance_params)
 
-    mock_irradiance_model.assert_called_once_with(
-        horizon_band_angle=irradiance_params['horizon_band_angle'])
+    np.testing.assert_almost_equal(np.nansum(report_no_params['qinc_back']),
+                                   541.7115807694377)
 
-    # Test parallel mode
-    mock_irradiance_model = mock.MagicMock()
-    mock_pool_obj = mock.MagicMock()
-    mock_pool.return_value = mock_pool_obj
-    report_builder = mock.MagicMock()
-    _ = run_parallel_engine(
-        report_builder, [],
-        [], [], [], [], [], [],
-        [], [], cls_engine=mock_engine,
-        cls_irradiance=mock_irradiance_model,
-        irradiance_model_params=irradiance_params,
-        n_processes=1
-    )
+    # The incident irradiance should be higher with larger horizon band
+    irradiance_params = {'horizon_band_angle': 15.}
+    report_w_params = run_parallel_engine(
+        ExampleReportBuilder, params_serial,
+        timestamps, dni, dhi, solar_zenith, solar_azimuth, surface_tilt,
+        surface_azimuth, params_serial['rho_ground'], n_processes=n_processes,
+        irradiance_model_params=irradiance_params)
 
-    mock_irradiance_model.assert_not_called()
-    mock_pool.assert_called_once_with(1)
-    # Check that irradiance params passed correctly
-    zipped_elements = [item
-                       for item in mock_pool_obj.map.call_args_list[0][0][1]]
-    assert zipped_elements[0][-2] == irradiance_params
+    np.testing.assert_almost_equal(np.nansum(report_w_params['qinc_back']),
+                                   554.5333279555168)

--- a/pvfactors/tests/test_run.py
+++ b/pvfactors/tests/test_run.py
@@ -1,7 +1,6 @@
 from pvfactors.run import run_timeseries_engine, run_parallel_engine
 from pvfactors.report import ExampleReportBuilder
 import numpy as np
-import pytest
 import mock
 
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ CLASSIFIERS = [
     'Topic :: Scientific/Engineering',
 ]
 
-TESTS_REQUIRES = ['pytest>=3.2.1', 'pytest-mock>=1.10.0']
+TESTS_REQUIRES = ['pytest>=3.2.1', 'pytest-mock>=1.10.0', 'mock']
 
 setup(name=DISTNAME,
       description=DESCRIPTION,


### PR DESCRIPTION
* in the functions of the ``run.py`` module, the irradiance models are currently initialized without any parameters: but may need to pass some, so this needs to be fixed