### PR TITLE
Update irradiance models

### DIFF
--- a/pvfactors/engine.py
+++ b/pvfactors/engine.py
@@ -92,13 +92,16 @@ class PVEngine(object):
         if np.isscalar(albedo):
             albedo = albedo * np.ones(self.n_points)
 
+        # Fit PV array
+        self.pvarray.fit(solar_zenith, solar_azimuth, surface_tilt,
+                         surface_azimuth)
+
         # Fit irradiance model
         self.irradiance.fit(timestamps, DNI, DHI, solar_zenith, solar_azimuth,
                             surface_tilt, surface_azimuth, albedo)
 
-        # Fit PV array
-        self.pvarray.fit(solar_zenith, solar_azimuth, surface_tilt,
-                         surface_azimuth)
+        # Add timeseries irradiance results to pvarray
+        self.irradiance.transform_ts(self.pvarray)
 
         # Skip timesteps when:
         #    - solar zenith > 90, ie the sun is down
@@ -139,7 +142,7 @@ class PVEngine(object):
 
             # Apply irradiance terms to pvarray
             irradiance_vec, rho_vec, invrho_vec, total_perez_vec = \
-                self.irradiance.transform(pvarray, idx=idx)
+                self.irradiance.get_full_modeling_vectors(pvarray, idx)
 
             # Prepare inputs to view factor calculator
             geom_dict = pvarray.dict_surfaces

--- a/pvfactors/geometry/pvarray.py
+++ b/pvfactors/geometry/pvarray.py
@@ -21,7 +21,7 @@ class OrderedPVArray(BasePVArray):
     y_ground = 0.  # ground will be at height = 0 by default
 
     def __init__(self, axis_azimuth=None, gcr=None, pvrow_height=None,
-                 n_pvrows=None, pvrow_width=None, surface_params=None,
+                 n_pvrows=None, pvrow_width=None, param_names=None,
                  cut=None):
         """Initialize ordered PV array.
         List of PV rows will be ordered from left to right.
@@ -38,7 +38,7 @@ class OrderedPVArray(BasePVArray):
             Number of PV rows in the PV array (Default = None)
         pvrow_width : float, optional
             Width of the PV rows in the 2D plane in [m] (Default = None)
-        surface_params : list of str, optional
+        param_names : list of str, optional
             List of surface parameter names for the PV surfaces
             (Default = None)
         cut : dict, optional
@@ -58,7 +58,7 @@ class OrderedPVArray(BasePVArray):
                          else None)
         self.width = pvrow_width
         self.n_pvrows = n_pvrows
-        self.surface_params = [] if surface_params is None else surface_params
+        self.param_names = [] if param_names is None else param_names
         self.cut = {} if cut is None else cut
 
         # These attributes will be updated at fitting time
@@ -80,14 +80,14 @@ class OrderedPVArray(BasePVArray):
         self.is_flat = None
 
     @classmethod
-    def init_from_dict(cls, pvarray_params, surface_params=None):
+    def init_from_dict(cls, pvarray_params, param_names=None):
         """Instantiate ordered PV array from dictionary of parameters
 
         Parameters
         ----------
         pvarray_params : dict
             The parameters defining the PV array
-        surface_params : list of str, optional
+        param_names : list of str, optional
             List of parameter names to pass to surfaces (Default = None)
 
         Returns
@@ -101,11 +101,11 @@ class OrderedPVArray(BasePVArray):
                    n_pvrows=pvarray_params['n_pvrows'],
                    pvrow_width=pvarray_params['pvrow_width'],
                    cut=pvarray_params.get('cut', {}),
-                   surface_params=surface_params)
+                   param_names=param_names)
 
     @classmethod
     def transform_from_dict_of_scalars(cls, pvarray_params,
-                                       surface_params=None):
+                                       param_names=None):
         """Instantiate, fit and transform ordered PV array using dictionary
         of scalar inputs.
 
@@ -113,7 +113,7 @@ class OrderedPVArray(BasePVArray):
         ----------
         pvarray_params : dict
             The parameters used for instantiation, fitting, and transformation
-        surface_params : list of str, optional
+        param_names : list of str, optional
             List of parameter names to pass to surfaces (Default = None)
 
         Returns
@@ -124,7 +124,7 @@ class OrderedPVArray(BasePVArray):
 
         # Create pv array
         pvarray = cls.init_from_dict(pvarray_params,
-                                     surface_params=surface_params)
+                                     param_names=param_names)
 
         # Fit pv array to scalar values
         solar_zenith = np.array([pvarray_params['solar_zenith']])
@@ -181,7 +181,7 @@ class OrderedPVArray(BasePVArray):
         self.ts_ground = TsGround.from_ts_pvrows_and_angles(
             self.ts_pvrows, alpha_vec, rotation_vec, y_ground=self.y_ground,
             flag_overlap=self.has_direct_shading,
-            surface_params=self.surface_params)
+            param_names=self.param_names)
 
         # Save surface rotation angles
         self.rotation_vec = rotation_vec
@@ -242,7 +242,7 @@ class OrderedPVArray(BasePVArray):
         xy_centers = [(X_ORIGIN_PVROWS + idx * self.distance,
                        self.height + self.y_ground)
                       for idx in range(self.n_pvrows)]
-        tilted_to_left = rotation_vec >= 0.
+        tilted_to_left = rotation_vec > 0.
         for idx_pvrow, xy_center in enumerate(xy_centers):
             # A special treatment needs to be applied to shaded lengths for
             # the PV rows at the edge of the PV array
@@ -267,7 +267,7 @@ class OrderedPVArray(BasePVArray):
                 xy_center, self.width, rotation_vec,
                 self.cut.get(idx_pvrow, {}), shaded_length_front,
                 shaded_length_back, index=idx_pvrow,
-                surface_params=self.surface_params))
+                param_names=self.param_names))
 
     def _calculate_interrow_shading(self, alpha_vec, rotation_vec):
         """Calculate the shaded length on front and back side of PV rows when

--- a/pvfactors/geometry/pvarray.py
+++ b/pvfactors/geometry/pvarray.py
@@ -68,6 +68,7 @@ class OrderedPVArray(BasePVArray):
         self.n_states = None
         self.has_direct_shading = None
         self.surface_tilt = None
+        self.rotation_vec = None
         self.shaded_length_front = None
         self.shaded_length_back = None
 
@@ -166,6 +167,8 @@ class OrderedPVArray(BasePVArray):
         # Calculate rotation angles
         rotation_vec = _get_rotation_from_tilt_azimuth(
             surface_azimuth, self.axis_azimuth, surface_tilt)
+        # Save rotation vector
+        self.rotation_vec = rotation_vec
 
         # Calculate the solar 2D vectors for all timestamps
         self.solar_2d_vectors = _get_solar_2d_vectors(

--- a/pvfactors/geometry/pvarray.py
+++ b/pvfactors/geometry/pvarray.py
@@ -104,8 +104,39 @@ class OrderedPVArray(BasePVArray):
                    param_names=param_names)
 
     @classmethod
-    def transform_from_dict_of_scalars(cls, pvarray_params,
-                                       param_names=None):
+    def fit_from_dict_of_scalars(cls, pvarray_params, param_names=None):
+        """Instantiate, and fit ordered PV array using dictionary
+        of scalar inputs.
+
+        Parameters
+        ----------
+        pvarray_params : dict
+            The parameters used for instantiation, fitting, and transformation
+        param_names : list of str, optional
+            List of parameter names to pass to surfaces (Default = None)
+
+        Returns
+        -------
+        OrderedPVArray
+            Initialized, and fitted Ordered PV Array
+        """
+
+        # Create pv array
+        pvarray = cls.init_from_dict(pvarray_params,
+                                     param_names=param_names)
+
+        # Fit pv array to scalar values
+        solar_zenith = np.array([pvarray_params['solar_zenith']])
+        solar_azimuth = np.array([pvarray_params['solar_azimuth']])
+        surface_tilt = np.array([pvarray_params['surface_tilt']])
+        surface_azimuth = np.array([pvarray_params['surface_azimuth']])
+        pvarray.fit(solar_zenith, solar_azimuth,
+                    surface_tilt, surface_azimuth)
+
+        return pvarray
+
+    @classmethod
+    def transform_from_dict_of_scalars(cls, pvarray_params, param_names=None):
         """Instantiate, fit and transform ordered PV array using dictionary
         of scalar inputs.
 
@@ -123,16 +154,8 @@ class OrderedPVArray(BasePVArray):
         """
 
         # Create pv array
-        pvarray = cls.init_from_dict(pvarray_params,
-                                     param_names=param_names)
-
-        # Fit pv array to scalar values
-        solar_zenith = np.array([pvarray_params['solar_zenith']])
-        solar_azimuth = np.array([pvarray_params['solar_azimuth']])
-        surface_tilt = np.array([pvarray_params['surface_tilt']])
-        surface_azimuth = np.array([pvarray_params['surface_azimuth']])
-        pvarray.fit(solar_zenith, solar_azimuth,
-                    surface_tilt, surface_azimuth)
+        pvarray = cls.fit_from_dict_of_scalars(pvarray_params,
+                                               param_names=param_names)
 
         # Transform pv array to first index (since scalar values were passed)
         pvarray.transform(0)

--- a/pvfactors/geometry/pvrow.py
+++ b/pvfactors/geometry/pvrow.py
@@ -55,7 +55,7 @@ class PVRow(GeometryCollection):
 
     @classmethod
     def from_linestring_coords(cls, coords, shaded=False, normal_vector=None,
-                               index=None, cut={}, surface_params=[]):
+                               index=None, cut={}, param_names=[]):
         """Create a PV row with a single PV surface and using linestring
         coordinates.
 
@@ -73,7 +73,7 @@ class PVRow(GeometryCollection):
             Scheme to decide how many segments to create on each side.
             Eg {'front': 3, 'back': 2} will lead to 3 segments on front side
             and 2 segments on back side. (Default = {})
-        surface_params : list of str, optional
+        param_names : list of str, optional
             Names of the surface parameters, eg reflectivity, total incident
             irradiance, temperature, etc. (Default = [])
 
@@ -85,7 +85,7 @@ class PVRow(GeometryCollection):
         front_side = PVRowSide.from_linestring_coords(
             coords, shaded=shaded, normal_vector=normal_vector,
             index=index_single_segment, n_segments=cut.get('front', 1),
-            surface_params=surface_params)
+            param_names=param_names)
         if normal_vector is not None:
             back_n_vec = - np.array(normal_vector)
         else:
@@ -93,14 +93,14 @@ class PVRow(GeometryCollection):
         back_side = PVRowSide.from_linestring_coords(
             coords, shaded=shaded, normal_vector=back_n_vec,
             index=index_single_segment, n_segments=cut.get('back', 1),
-            surface_params=surface_params)
+            param_names=param_names)
         return cls(front_side=front_side, back_side=back_side, index=index,
                    original_linestring=LineString(coords))
 
     @classmethod
     def from_center_tilt_width(cls, xy_center, tilt, width, surface_azimuth,
                                axis_azimuth, shaded=False, normal_vector=None,
-                               index=None, cut={}, surface_params=[]):
+                               index=None, cut={}, param_names=[]):
         """Create a PV row using mainly the coordinates of the line center,
         a tilt angle, and its length.
 
@@ -127,7 +127,7 @@ class PVRow(GeometryCollection):
             Scheme to decide how many segments to create on each side.
             Eg {'front': 3, 'back': 2} will lead to 3 segments on front side
             and 2 segments on back side. (Default = {})
-        surface_params : list of str, optional
+        param_names : list of str, optional
             Names of the surface parameters, eg reflectivity, total incident
             irradiance, temperature, etc. (Default = [])
 
@@ -140,7 +140,7 @@ class PVRow(GeometryCollection):
         return cls.from_linestring_coords(coords, shaded=shaded,
                                           normal_vector=normal_vector,
                                           index=index, cut=cut,
-                                          surface_params=surface_params)
+                                          param_names=param_names)
 
     def plot(self, ax, color_shaded=COLOR_DIC['pvrow_shaded'],
              color_illum=COLOR_DIC['pvrow_illum'], with_index=False):

--- a/pvfactors/geometry/timeseries.py
+++ b/pvfactors/geometry/timeseries.py
@@ -495,6 +495,10 @@ class TsDualSegment(object):
     def centroid(self):
         return self.coords.centroid
 
+    def get_param_weighted(self, param):
+
+        return self.get_param_ww(param) / self.length
+
     def get_param_ww(self, param):
 
         value = 0
@@ -549,6 +553,8 @@ class TsGround(object):
         self.cut_point_coords = [] if cut_point_coords is None \
             else cut_point_coords
         self.y_ground = y_ground
+        self.shaded_params = dict.fromkeys(self.surface_params)
+        self.illum_params = dict.fromkeys(self.surface_params)
 
     @classmethod
     def from_ts_pvrows_and_angles(cls, list_ts_pvrows, alpha_vec, rotation_vec,

--- a/pvfactors/geometry/timeseries.py
+++ b/pvfactors/geometry/timeseries.py
@@ -694,9 +694,11 @@ class TsGround(object):
             ordered_shadow_coords = [shadow.coords.at(idx)
                                      for shadow in self.shadows]
         # Create parameters at given idx
-        illum_params = {k: (None if val is None else val[idx])
+        illum_params = {k: (val if (val is None) or np.isscalar(val)
+                            else val[idx])
                         for k, val in self.illum_params.items()}
-        shaded_params = {k: (None if val is None else val[idx])
+        shaded_params = {k: (None if (val is None) or np.isscalar(val)
+                             else val[idx])
                          for k, val in self.shaded_params.items()}
         # Return ground geometry
         return PVGround.from_ordered_shadow_and_cut_pt_coords(
@@ -837,7 +839,8 @@ class TsSurface(object):
             n_vector = (self.n_vector[:, idx] if self.n_vector is not None
                         else None)
             # Get params at idx
-            params = {k: (None if val is None else val[idx])
+            params = {k: (None if (val is None) or np.isscalar(val)
+                          else val[idx])
                       for k, val in self.params.items()}
             # Return a pv surface geometry with given params
             return PVSurface(self.coords.at(idx), shaded=shaded,

--- a/pvfactors/geometry/timeseries.py
+++ b/pvfactors/geometry/timeseries.py
@@ -45,7 +45,7 @@ class TsPVRow(object):
     @classmethod
     def from_raw_inputs(cls, xy_center, width, rotation_vec,
                         cut, shaded_length_front, shaded_length_back,
-                        index=None, surface_params=None):
+                        index=None, param_names=None):
         """Create timeseries PV row using raw inputs.
         Note: shading will always be zero when pv rows are flat.
 
@@ -66,7 +66,7 @@ class TsPVRow(object):
             Timeseries values of back side shaded length [m]
         index : int, optional
             Index of the pv row (default = None)
-        surface_params : list of str, optional
+        param_names : list of str, optional
             List of names of surface parameters to use when creating geometries
             (Default = None)
 
@@ -85,12 +85,12 @@ class TsPVRow(object):
         ts_front = TsSide.from_raw_inputs(
             xy_center, width, rotation_vec, cut.get('front', 1),
             shaded_length_front, n_vector=normal_vec_front,
-            surface_params=surface_params)
+            param_names=param_names)
         # Calculate back side coords
         ts_back = TsSide.from_raw_inputs(
             xy_center, width, rotation_vec, cut.get('back', 1),
             shaded_length_back, n_vector=-normal_vec_front,
-            surface_params=surface_params)
+            param_names=param_names)
 
         return cls(ts_front, ts_back, xy_center, index=index,
                    full_pvrow_coords=pvrow_coords)
@@ -202,7 +202,7 @@ class TsSide(object):
 
     @classmethod
     def from_raw_inputs(cls, xy_center, width, rotation_vec, cut,
-                        shaded_length, n_vector=None, surface_params=None):
+                        shaded_length, n_vector=None, param_names=None):
         """Create timeseries side using raw PV row inputs.
         Note: shading will always be zero when PV rows are flat.
 
@@ -221,7 +221,7 @@ class TsSide(object):
             Timeseries values of side shaded length from lowest point [m]
         n_vector : np.ndarray, optional
             Timeseries normal vectors of the side
-        surface_params : list of str, optional
+        param_names : list of str, optional
             List of names of surface parameters to use when creating geometries
             (Default = None)
 
@@ -286,9 +286,9 @@ class TsSide(object):
                 np.array([[x1_shaded, y1_shaded], [x2_shaded, y2_shaded]]))
             # Create illuminated and shaded surfaces
             illum = TsSurface(illum_coords, n_vector=n_vector,
-                              surface_params=surface_params)
+                              param_names=param_names)
             shaded = TsSurface(shaded_coords, n_vector=n_vector,
-                               surface_params=surface_params)
+                               param_names=param_names)
             # Create dual segment
             segment = TsDualSegment(segment_coords, illum, shaded,
                                     n_vector=n_vector)
@@ -467,14 +467,14 @@ class TsDualSegment(object):
             else [illum_surface]
         illum_collection = ShadeCollection(
             list_surfaces=list_illum_surfaces, shaded=False,
-            surface_params=None)
+            param_names=None)
         # Create shaded collection
         shaded_surface = self.shaded.at(idx, shaded=True)
         list_shaded_surfaces = [] if shaded_surface.is_empty \
             else [shaded_surface]
         shaded_collection = ShadeCollection(
             list_surfaces=list_shaded_surfaces, shaded=True,
-            surface_params=None)
+            param_names=None)
         # Create PV segment
         segment = PVSegment(illum_collection=illum_collection,
                             shaded_collection=shaded_collection,
@@ -526,7 +526,7 @@ class TsGround(object):
     PV ground geometry class, and it will store timeseries coordinates
     for ground shadows and pv row cut points."""
 
-    def __init__(self, shadow_surfaces, surface_params=None,
+    def __init__(self, shadow_surfaces, param_names=None,
                  flag_overlap=None, cut_point_coords=None, y_ground=None):
         """Initialize timeseries ground using list of timeseries surfaces
         for the ground shadows
@@ -535,7 +535,7 @@ class TsGround(object):
         ----------
         shadow_surfaces : list of :py:class:`~pvfactors.geometry.timeseries.TsSurface`
             Timeseries surfaces for ground shadows
-        surface_params : list of str, optional
+        param_names : list of str, optional
             List of names of surface parameters to use when creating geometries
             (Default = None)
         flag_overlap : list of bool, optional
@@ -548,18 +548,18 @@ class TsGround(object):
             Y coordinate of flat ground [m] (Default=None)
         """
         self.shadows = shadow_surfaces
-        self.surface_params = [] if surface_params is None else surface_params
+        self.param_names = [] if param_names is None else param_names
         self.flag_overlap = flag_overlap
         self.cut_point_coords = [] if cut_point_coords is None \
             else cut_point_coords
         self.y_ground = y_ground
-        self.shaded_params = dict.fromkeys(self.surface_params)
-        self.illum_params = dict.fromkeys(self.surface_params)
+        self.shaded_params = dict.fromkeys(self.param_names)
+        self.illum_params = dict.fromkeys(self.param_names)
 
     @classmethod
     def from_ts_pvrows_and_angles(cls, list_ts_pvrows, alpha_vec, rotation_vec,
                                   y_ground=Y_GROUND, flag_overlap=None,
-                                  surface_params=None):
+                                  param_names=None):
         """Create timeseries ground from list of timeseries PV rows, and
         PV array and solar angles.
 
@@ -576,7 +576,7 @@ class TsGround(object):
         flag_overlap : list of bool, optional
             Flags indicating if the ground shadows are overlapping, for all
             time steps (Default=None). I.e. is there direct shading on pv rows?
-        surface_params : list of str, optional
+        param_names : list of str, optional
             List of names of surface parameters to use when creating geometries
             (Default = None)
         """
@@ -611,12 +611,12 @@ class TsGround(object):
         ground_shadow_coords = np.array(ground_shadow_coords)
         return cls.from_ordered_shadows_coords(
             ground_shadow_coords, flag_overlap=flag_overlap,
-            cut_point_coords=cut_point_coords, surface_params=surface_params,
+            cut_point_coords=cut_point_coords, param_names=param_names,
             y_ground=y_ground)
 
     @classmethod
     def from_ordered_shadows_coords(cls, shadow_coords, flag_overlap=None,
-                                    surface_params=None, cut_point_coords=None,
+                                    param_names=None, cut_point_coords=None,
                                     y_ground=Y_GROUND):
         """Create timeseries ground from list of ground shadow coordinates.
 
@@ -627,7 +627,7 @@ class TsGround(object):
         flag_overlap : list of bool, optional
             Flags indicating if the ground shadows are overlapping, for all
             time steps (Default=None). I.e. is there direct shading on pv rows?
-        surface_params : list of str, optional
+        param_names : list of str, optional
             List of names of surface parameters to use when creating geometries
             (Default = None)
         cut_point_coords : list of :py:class:`~pvfactors.geometry.timeseries.TsPointCoords`, optional
@@ -651,7 +651,7 @@ class TsGround(object):
                                            coords.b2.x)
         # Create shadow surfaces
         ts_shadows = [TsSurface(coords) for coords in list_coords]
-        return cls(ts_shadows, surface_params=surface_params,
+        return cls(ts_shadows, param_names=param_names,
                    flag_overlap=flag_overlap,
                    cut_point_coords=cut_point_coords, y_ground=y_ground)
 
@@ -681,6 +681,7 @@ class TsGround(object):
         cut_point_coords = ([cut_point.at(idx)
                              for cut_point in self.cut_point_coords]
                             if with_cut_points else [])
+        # Decide whether to merge all shadows or not
         if merge_if_flag_overlap and (self.flag_overlap is not None):
             is_overlap = self.flag_overlap[idx]
             if is_overlap and (len(self.shadows) > 1):
@@ -692,11 +693,16 @@ class TsGround(object):
         else:
             ordered_shadow_coords = [shadow.coords.at(idx)
                                      for shadow in self.shadows]
-        pvground = PVGround.from_ordered_shadow_and_cut_pt_coords(
+        # Create parameters at given idx
+        illum_params = {k: (None if val is None else val[idx])
+                        for k, val in self.illum_params.items()}
+        shaded_params = {k: (None if val is None else val[idx])
+                         for k, val in self.shaded_params.items()}
+        # Return ground geometry
+        return PVGround.from_ordered_shadow_and_cut_pt_coords(
             x_min_max=x_min_max, ordered_shadow_coords=ordered_shadow_coords,
-            cut_point_coords=cut_point_coords,
-            surface_params=self.surface_params)
-        return pvground
+            cut_point_coords=cut_point_coords, param_names=self.param_names,
+            illum_params=illum_params, shaded_params=shaded_params)
 
     def plot_at_idx(self, idx, ax, color_shaded=COLOR_DIC['pvrow_shaded'],
                     color_illum=COLOR_DIC['pvrow_illum'], x_min_max=None,
@@ -790,7 +796,7 @@ class TsSurface(object):
     """Timeseries surface class: vectorized representation of PV surface
     geometries."""
 
-    def __init__(self, coords, n_vector=None, surface_params=None):
+    def __init__(self, coords, n_vector=None, param_names=None):
         """Initialize timeseries surface using timeseries coordinates.
 
         Parameters
@@ -803,11 +809,11 @@ class TsSurface(object):
             Timeseries normal vectors of the side (Default = None)
         """
         self.coords = coords
-        self.surface_params = [] if surface_params is None else surface_params
+        self.param_names = [] if param_names is None else param_names
         # TODO: the following should probably be turned into properties,
         # because if the coords change, they won't be altered. But speed...
         self.n_vector = n_vector
-        self.params = dict.fromkeys(self.surface_params)
+        self.params = dict.fromkeys(self.param_names)
 
     def at(self, idx, shaded=None):
         """Generate a PV segment geometry for the desired index.
@@ -827,13 +833,17 @@ class TsSurface(object):
             # return an empty geometry
             return GeometryCollection()
         else:
-            # Get normal vector at that time
+            # Get normal vector at idx
             n_vector = (self.n_vector[:, idx] if self.n_vector is not None
                         else None)
-            # Return a pv surface geometry
+            # Get params at idx
+            params = {k: (None if val is None else val[idx])
+                      for k, val in self.params.items()}
+            # Return a pv surface geometry with given params
             return PVSurface(self.coords.at(idx), shaded=shaded,
                              normal_vector=n_vector,
-                             surface_params=self.surface_params)
+                             param_names=self.param_names,
+                             params=params)
 
     def plot_at_idx(self, idx, ax, color):
         """Plot timeseries PV row at a certain index, only if it's not

--- a/pvfactors/geometry/timeseries.py
+++ b/pvfactors/geometry/timeseries.py
@@ -362,21 +362,60 @@ class TsSide(object):
 
     @property
     def length(self):
+        """Timeseries length of side."""
         length = 0.
         for seg in self.list_segments:
             length += seg.length
         return length
 
     def get_param_weighted(self, param):
+        """Get timeseries parameter for the side, after weighting by
+        surface length.
+
+        Parameters
+        ----------
+        param : str
+            Name of parameter
+
+        Returns
+        -------
+        np.ndarray
+            Weighted parameter values
+        """
         return self.get_param_ww(param) / self.length
 
     def get_param_ww(self, param):
+        """Get timeseries parameter from the side's surfaces with weight, i.e.
+        after multiplying by the surface lengths.
+
+        Parameters
+        ----------
+        param: str
+            Surface parameter to return
+
+        Returns
+        -------
+        np.ndarray
+            Timeseries parameter values multiplied by weights
+
+        Raises
+        ------
+        KeyError
+            if parameter name not in a surface parameters
+        """
         value = 0.
         for seg in self.list_segments:
             value += seg.get_param_ww(param)
         return value
 
     def update_params(self, new_dict):
+        """Update timeseries surface parameters of the side.
+
+        Parameters
+        ----------
+        new_dict : dict
+            Parameters to add or update for the surfaces
+        """
 
         for seg in self.list_segments:
             seg.update_params(new_dict)
@@ -493,13 +532,39 @@ class TsDualSegment(object):
 
     @property
     def centroid(self):
+        """Timeseries point coordinates of the segment's centroid"""
         return self.coords.centroid
 
     def get_param_weighted(self, param):
+        """Get timeseries parameter for the segment, after weighting by
+        surface length.
 
+        Parameters
+        ----------
+        param : str
+            Name of parameter
+
+        Returns
+        -------
+        np.ndarray
+            Weighted parameter values
+        """
         return self.get_param_ww(param) / self.length
 
     def get_param_ww(self, param):
+        """Get timeseries parameter from the segment's surfaces with weight,
+        i.e. after multiplying by the surface lengths.
+
+        Parameters
+        ----------
+        param: str
+            Surface parameter to return
+
+        Returns
+        -------
+        np.ndarray
+            Timeseries parameter values multiplied by weights
+        """
 
         value = 0
         value += self.illum.get_param(param) * self.illum.length
@@ -507,6 +572,13 @@ class TsDualSegment(object):
         return value
 
     def update_params(self, new_dict):
+        """Update timeseries surface parameters of the segment.
+
+        Parameters
+        ----------
+        new_dict : dict
+            Parameters to add or update for the surfaces
+        """
         self.illum.update_params(new_dict)
         self.shaded.update_params(new_dict)
 
@@ -876,12 +948,32 @@ class TsSurface(object):
 
     @property
     def centroid(self):
+        """Timeseries point coordinates of the surface's centroid"""
         return self.coords.centroid
 
     def get_param(self, param):
+        """Get timeseries parameter values of surface
+
+        Parameters
+        ----------
+        param: str
+            Surface parameter to return
+
+        Returns
+        -------
+        np.ndarray
+            Timeseries parameter values
+        """
         return self.params[param]
 
     def update_params(self, new_dict):
+        """Update timeseries surface parameters.
+
+        Parameters
+        ----------
+        new_dict : dict
+            Parameters to add or update for the surface
+        """
         self.params.update(new_dict)
 
     @property
@@ -944,6 +1036,7 @@ class TsLineCoords(object):
 
     @property
     def centroid(self):
+        """Timeseries point coordinates of the line coordinates"""
         dy = self.b2.y - self.b1.y
         dx = self.b2.x - self.b1.x
         return TsPointCoords(self.b1.x + 0.5 * dx, self.b1.y + 0.5 * dy)

--- a/pvfactors/irradiance/base.py
+++ b/pvfactors/irradiance/base.py
@@ -8,23 +8,23 @@ class BaseModel(object):
     cats = None
     irradiance_comp = None
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         """Not implemented"""
         raise NotImplementedError
 
-    def fit(self):
+    def fit(self, *args, **kwargs):
         """Not implemented"""
         raise NotImplementedError
 
-    def transform(self):
+    def transform(self, *args, **kwargs):
         """Not implemented"""
         raise NotImplementedError
 
-    def transform_ts(self):
+    def transform_ts(self, *args, **kwargs):
         """Not implemented"""
         raise NotImplementedError
 
-    def get_full_modeling_vectors(self):
+    def get_full_modeling_vectors(self, *args, **kwargs):
         """Not implemented"""
         raise NotImplementedError
 

--- a/pvfactors/irradiance/base.py
+++ b/pvfactors/irradiance/base.py
@@ -20,6 +20,14 @@ class BaseModel(object):
         """Not implemented"""
         raise NotImplementedError
 
+    def transform_ts(self):
+        """Not implemented"""
+        raise NotImplementedError
+
+    def get_full_modeling_vectors(self):
+        """Not implemented"""
+        raise NotImplementedError
+
     def get_modeling_vectors(self, pvarray):
         """Get vector of summed up irradiance values from a PV array, as well
         as the inverse reflectivity values (the latter need to be named

--- a/pvfactors/irradiance/models.py
+++ b/pvfactors/irradiance/models.py
@@ -128,19 +128,6 @@ class IsotropicOrdered(BaseModel):
         idx : int, optional
             Index of the irradiance values to apply to the PV array (in the
             whole timeseries values)
-
-        Returns
-        -------
-        irradiance_vec : numpy array
-            List of summed up non-reflective irradiance values for all surfaces
-            and sky
-        rho_vec : numpy array
-            List of reflectivity values for all surfaces and sky
-        invrho_vec : numpy array
-            List of inverse reflectivity for all surfaces and sky
-        total_perez_vec : numpy array
-            List of total perez transposed irradiance values for all surfaces
-            and sky
         """
 
         for seg in pvarray.ground.list_segments:
@@ -183,6 +170,14 @@ class IsotropicOrdered(BaseModel):
                      'total_perez': 0.})
 
     def transform_ts(self, pvarray):
+        """Apply calculated irradiance values to PV array timeseries
+        geometries: assign values as parameters to timeseries surfaces.
+
+        Parameters
+        ----------
+        pvarray : PV array object
+            PV array on which the calculated irradiance values will be applied
+        """
 
         # Prepare variables
         n_steps = self.n_steps
@@ -231,7 +226,30 @@ class IsotropicOrdered(BaseModel):
                      'total_perez': np.zeros(n_steps)})
 
     def get_full_modeling_vectors(self, pvarray, idx):
+        """Get the modeling vectors used in matrix calculations of mathematical
+        model.
 
+        Parameters
+        ----------
+        pvarray : PV array object
+            PV array on which the calculated irradiance values will be applied
+        idx : int, optional
+            Index of the irradiance values to apply to the PV array (in the
+            whole timeseries values)
+
+        Returns
+        -------
+        irradiance_vec : numpy array
+            List of summed up non-reflective irradiance values for all surfaces
+            and sky
+        rho_vec : numpy array
+            List of reflectivity values for all surfaces and sky
+        invrho_vec : numpy array
+            List of inverse reflectivity for all surfaces and sky
+        total_perez_vec : numpy array
+            List of total perez transposed irradiance values for all surfaces
+            and sky
+        """
         # Sum up the necessary parameters to form the irradiance vector
         irradiance_vec, rho_vec, inv_rho_vec, total_perez_vec = \
             self.get_modeling_vectors(pvarray)
@@ -388,6 +406,14 @@ class HybridPerezOrdered(BaseModel):
         self.total_perez['sky'] = luminance_isotropic
 
     def transform_ts(self, pvarray):
+        """Apply calculated irradiance values to PV array timeseries
+        geometries: assign values as parameters to timeseries surfaces.
+
+        Parameters
+        ----------
+        pvarray : PV array object
+            PV array on which the calculated irradiance values will be applied
+        """
 
         # Prepare variables
         n_steps = self.n_steps
@@ -476,19 +502,6 @@ class HybridPerezOrdered(BaseModel):
         idx : int, optional
             Index of the irradiance values to apply to the PV array (in the
             whole timeseries values)
-
-        Returns
-        -------
-        irradiance_vec : numpy array
-            List of summed up non-reflective irradiance values for all surfaces
-            and sky
-        rho_vec : numpy array
-            List of reflectivity values for all surfaces and sky
-        invrho_vec : numpy array
-            List of inverse reflectivity for all surfaces and sky
-        total_perez_vec : numpy array
-            List of total perez transposed irradiance values for all surfaces
-            and sky
         """
 
         for seg in pvarray.ground.list_segments:
@@ -558,6 +571,30 @@ class HybridPerezOrdered(BaseModel):
                          'total_perez': 0.})
 
     def get_full_modeling_vectors(self, pvarray, idx):
+        """Get the modeling vectors used in matrix calculations of mathematical
+        model.
+
+        Parameters
+        ----------
+        pvarray : PV array object
+            PV array on which the calculated irradiance values will be applied
+        idx : int, optional
+            Index of the irradiance values to apply to the PV array (in the
+            whole timeseries values)
+
+        Returns
+        -------
+        irradiance_vec : numpy array
+            List of summed up non-reflective irradiance values for all surfaces
+            and sky
+        rho_vec : numpy array
+            List of reflectivity values for all surfaces and sky
+        invrho_vec : numpy array
+            List of inverse reflectivity for all surfaces and sky
+        total_perez_vec : numpy array
+            List of total perez transposed irradiance values for all surfaces
+            and sky
+        """
 
         # Sum up the necessary parameters to form the irradiance vector
         irradiance_vec, rho_vec, inv_rho_vec, total_perez_vec = \
@@ -609,6 +646,28 @@ class HybridPerezOrdered(BaseModel):
     def calculate_horizon_shading_pct_ts(self, ts_pvrows, ts_point_coords,
                                          pvrow_idx, tilted_to_left,
                                          is_back_side=True):
+        """Calculate horizon band shading percentage on surfaces of the ordered
+        PV array, in a vectorized way.
+
+        Parameters
+        ----------
+        ts_pvrows : list of :py:class:`~pvfactors.geometry.timeseries.TsPVRow`
+            List of timeseries PV rows in the PV array
+        ts_point_coords : :py:class:`~pvfactors.geometry.timeseries.TsPointCoords`
+            Timeseries coordinates of point that suffers horizon band shading
+        pvrow_idx : int
+            Index of PV row on which the above point is located
+        tilted_to_left : list of bool
+            Flags indicating when the PV rows are strictly tilted to the left
+        is_back_side : bool
+            Flag indicating if point is located on back side of PV row
+
+        Returns
+        -------
+        horizon_shading_pct : np.ndarray
+            Percentage vector of horizon band irradiance shading
+            (from 0 to 100)
+        """
         n_pvrows = len(ts_pvrows)
         if pvrow_idx == 0:
             shading_pct_left = np.zeros_like(tilted_to_left)

--- a/pvfactors/irradiance/models.py
+++ b/pvfactors/irradiance/models.py
@@ -327,7 +327,12 @@ class HybridPerezOrdered(BaseModel):
             ~front_is_illum, poa_circumsolar_back, 0.)
         self.horizon['front_pvrow'] = poa_horizon
         self.horizon['back_pvrow'] = poa_horizon
-        self.total_perez['front_pvrow'] = total_perez_front_pvrow
+        self.total_perez['front_illum_pvrow'] = total_perez_front_pvrow
+        self.total_perez['front_shaded_pvrow'] = (
+            total_perez_front_pvrow - self.direct['front_pvrow'])
+        self.total_perez['ground_shaded'] = DHI
+        self.total_perez['ground_illum'] = GHI
+        self.total_perez['sky'] = luminance_isotropic
 
     def transform(self, pvarray, idx=0):
         """Apply calculated irradiance values to PV array, as well as
@@ -362,14 +367,14 @@ class HybridPerezOrdered(BaseModel):
                  'horizon': 0.,
                  'rho': self.albedo[idx],
                  'inv_rho': 1. / self.albedo[idx],
-                 'total_perez': self.GHI[idx]})
+                 'total_perez': self.total_perez['ground_illum'][idx]})
             seg.shaded_collection.update_params(
                 {'direct': 0.,
                  'circumsolar': 0.,
                  'horizon': 0.,
                  'rho': self.albedo[idx],
                  'inv_rho': 1. / self.albedo[idx],
-                 'total_perez': self.DHI[idx]})
+                 'total_perez': self.total_perez['ground_shaded'][idx]})
 
         pvrows = pvarray.pvrows
         for idx_pvrow, pvrow in enumerate(pvarray.pvrows):
@@ -381,15 +386,16 @@ class HybridPerezOrdered(BaseModel):
                      'horizon': self.horizon['front_pvrow'][idx],
                      'rho': self.rho_front,
                      'inv_rho': 1. / self.rho_front,
-                     'total_perez': self.total_perez['front_pvrow'][idx]})
+                     'total_perez':
+                     self.total_perez['front_illum_pvrow'][idx]})
                 seg.shaded_collection.update_params(
                     {'direct': 0.,
                      'circumsolar': 0.,
                      'horizon': self.horizon['front_pvrow'][idx],
                      'rho': self.rho_front,
                      'inv_rho': 1. / self.rho_front,
-                     'total_perez': self.total_perez['front_pvrow'][idx] -
-                     self.direct['front_pvrow'][idx]})
+                     'total_perez':
+                     self.total_perez['front_shaded_pvrow'][idx]})
             # Back: apply back surface horizon shading
             for seg in pvrow.back.list_segments:
                 # Illum

--- a/pvfactors/irradiance/models.py
+++ b/pvfactors/irradiance/models.py
@@ -212,7 +212,7 @@ class IsotropicOrdered(BaseModel):
                      'inv_rho': inv_rho_front,
                      'total_perez': self.total_perez['front_pvrow']})
                 ts_seg.shaded.update_params(
-                    {'direct': 0.,
+                    {'direct': np.zeros(n_steps),
                      'rho': rho_front,
                      'inv_rho': inv_rho_front,
                      'total_perez': self.total_perez['front_pvrow']

--- a/pvfactors/irradiance/models.py
+++ b/pvfactors/irradiance/models.py
@@ -506,6 +506,8 @@ class HybridPerezOrdered(BaseModel):
                          'inv_rho': 1. / self.rho_back,
                          'total_perez': 0.})
 
+    def get_full_modeling_vectors(self, pvarray, idx):
+
         # Sum up the necessary parameters to form the irradiance vector
         irradiance_vec, rho_vec, inv_rho_vec, total_perez_vec = \
             self.get_modeling_vectors(pvarray)
@@ -563,8 +565,8 @@ class HybridPerezOrdered(BaseModel):
             high_pt_left = ts_pvrows[
                 pvrow_idx - 1].full_pvrow_coords.highest_point
             shading_angle_left = np.rad2deg(np.abs(np.arctan(
-                high_pt_left.y - ts_point_coords.y,
-                high_pt_left.x - ts_point_coords.x)))
+                (high_pt_left.y - ts_point_coords.y)
+                / (high_pt_left.x - ts_point_coords.x))))
             shading_pct_left = calculate_horizon_band_shading(
                 shading_angle_left, self.horizon_band_angle)
 
@@ -574,8 +576,8 @@ class HybridPerezOrdered(BaseModel):
             high_pt_right = ts_pvrows[
                 pvrow_idx + 1].full_pvrow_coords.highest_point
             shading_angle_right = np.rad2deg(np.abs(np.arctan(
-                high_pt_right.y - ts_point_coords.y,
-                high_pt_right.x - ts_point_coords.x)))
+                (high_pt_right.y - ts_point_coords.y)
+                / (high_pt_right.x - ts_point_coords.x))))
             shading_pct_right = calculate_horizon_band_shading(
                 shading_angle_right, self.horizon_band_angle)
 

--- a/pvfactors/irradiance/utils.py
+++ b/pvfactors/irradiance/utils.py
@@ -350,7 +350,7 @@ def calculate_horizon_band_shading(shading_angle, horizon_band_angle):
 
     Parameters
     ----------
-    shading_angle : float
+    shading_angle : np.ndarray
         the elevation angle to use for shading
     horizon_band_angle : float
         the total elevation angle of the horizon band
@@ -361,12 +361,8 @@ def calculate_horizon_band_shading(shading_angle, horizon_band_angle):
         shading percentage of horizon band
 
     """
-    percent_shading = 0.
-    if shading_angle >= horizon_band_angle:
-        percent_shading = 100.
-    elif (shading_angle >= 0) | (shading_angle < horizon_band_angle):
-        percent_shading = 100. * shading_angle / horizon_band_angle
-    else:
-        # No shading
-        pass
+    percent_shading = np.where(shading_angle >= horizon_band_angle, 100., 0.)
+    percent_shading = np.where(
+        (shading_angle >= 0) & (shading_angle < horizon_band_angle),
+        100. * shading_angle / horizon_band_angle, percent_shading)
     return percent_shading

--- a/pvfactors/tests/test_engine.py
+++ b/pvfactors/tests/test_engine.py
@@ -90,7 +90,7 @@ def test_pvengine_ts_inputs_perez(params_serial,
     # Create engine
     irradiance_model = HybridPerezOrdered()
     pvarray = OrderedPVArray.init_from_dict(
-        params_serial, surface_params=irradiance_model.params)
+        params_serial, param_names=irradiance_model.params)
     eng = PVEngine(pvarray, irradiance_model=irradiance_model)
 
     # Fit engine
@@ -117,7 +117,7 @@ def test_fast_pvengine_float_inputs_perez(params):
     # Prepare some engine inputs
     irradiance_model = HybridPerezOrdered()
     pvarray = OrderedPVArray.init_from_dict(
-        params, surface_params=irradiance_model.params)
+        params, param_names=irradiance_model.params)
     fast_mode_pvrow_index = 1
 
     # Create engine object

--- a/pvfactors/tests/test_geometry/test_pvarray.py
+++ b/pvfactors/tests/test_geometry/test_pvarray.py
@@ -361,11 +361,11 @@ def test_view_matrix(params):
     # TODO: test values against saved array
 
 
-def test_surface_params(params):
+def test_param_names(params):
 
-    surface_params = ['qinc']
+    param_names = ['qinc']
     pvarray = OrderedPVArray.transform_from_dict_of_scalars(
-        params, surface_params=surface_params)
+        params, param_names=param_names)
 
     # Set all surfaces parameters to 1
     pvarray.update_params({'qinc': 1})
@@ -373,7 +373,7 @@ def test_surface_params(params):
     # Check that all surfaces of the correct surface params
     all_surfaces = pvarray.all_surfaces
     for surf in all_surfaces:
-        assert surf.surface_params == surface_params
+        assert surf.param_names == param_names
         assert surf.get_param('qinc') == 1
 
     # Check weighted values

--- a/pvfactors/tests/test_geometry/test_timeseries.py
+++ b/pvfactors/tests/test_geometry/test_timeseries.py
@@ -88,12 +88,12 @@ def test_ts_pvrow_to_geometry():
         'shaded_length_front': [1.3, 0., 1.9],
         'shaded_length_back': [0, 0.3, 0.6]})
     cut = {'front': 3, 'back': 4}
-    surface_params = ['test1', 'test2']
+    param_names = ['test1', 'test2']
 
     ts_pvrow = TsPVRow.from_raw_inputs(
         xy_center, width, df_inputs.rotation_vec,
         cut, df_inputs.shaded_length_front,
-        df_inputs.shaded_length_back, surface_params=surface_params)
+        df_inputs.shaded_length_back, param_names=param_names)
 
     pvrow = ts_pvrow.at(0)
     # Check classes of geometries
@@ -116,8 +116,8 @@ def test_ts_pvrow_to_geometry():
     expected_n_vec_front = np.array([-0.68404029, 1.87938524])
     np.testing.assert_allclose(n_vector_front, expected_n_vec_front)
     np.testing.assert_allclose(n_vector_back, - expected_n_vec_front)
-    assert front_surface.surface_params == surface_params
-    assert back_surface.surface_params == surface_params
+    assert front_surface.param_names == param_names
+    assert back_surface.param_names == param_names
 
 
 def test_ts_ground_from_ts_pvrow():
@@ -131,18 +131,18 @@ def test_ts_ground_from_ts_pvrow():
         'shaded_length_front': [1.3, 0., 1.9],
         'shaded_length_back': [0, 0.3, 0.6]})
     cut = {'front': 3, 'back': 4}
-    surface_params = ['test1', 'test2']
+    param_names = ['test1', 'test2']
 
     ts_pvrow = TsPVRow.from_raw_inputs(
         xy_center, width, df_inputs.rotation_vec,
         cut, df_inputs.shaded_length_front,
-        df_inputs.shaded_length_back, surface_params=surface_params)
+        df_inputs.shaded_length_back, param_names=param_names)
 
     # Create ground from it
     alpha_vec = np.deg2rad([80., 90., 70.])
     ts_ground = TsGround.from_ts_pvrows_and_angles(
         [ts_pvrow], alpha_vec, df_inputs.rotation_vec,
-        surface_params=surface_params)
+        param_names=param_names)
 
     assert len(ts_ground.shadows) == 1
     # Check at specific times
@@ -157,7 +157,7 @@ def test_ts_ground_from_ts_pvrow():
     np.testing.assert_allclose(ts_ground.at(2).shaded_length, width)  # flat
     # Check that all have surface params
     for surf in ground_0.all_surfaces:
-        assert surf.surface_params == surface_params
+        assert surf.param_names == param_names
 
     is_ci = os.environ.get('CI', False)
 

--- a/pvfactors/tests/test_irradiance/test_models.py
+++ b/pvfactors/tests/test_irradiance/test_models.py
@@ -538,7 +538,7 @@ def test_hybridperez_horizon_shading_ts():
 
     # Check that values stay consistent
     expected_pct_shading = np.array(
-        [64.695221, 33.081398, 64.695221, 93.574956, 0.])
+        [17.163813, 8.667262, 17.163813, 25.317135, 0.])
     np.testing.assert_allclose(expected_pct_shading, horizon_pct_shading)
 
 

--- a/pvfactors/tests/test_irradiance/test_utils.py
+++ b/pvfactors/tests/test_irradiance/test_utils.py
@@ -1,6 +1,7 @@
 import numpy as np
 from pvfactors.irradiance.utils import \
-    perez_diffuse_luminance, breakup_df_inputs, calculate_circumsolar_shading
+    perez_diffuse_luminance, breakup_df_inputs, \
+    calculate_circumsolar_shading, calculate_horizon_band_shading
 
 
 def test_perez_diffuse_luminance(df_perez_luminance):
@@ -39,3 +40,14 @@ def test_calculate_circumsolar_shading():
     rtol = 1e-8
     np.testing.assert_allclose(expected_disk_shading_perc, percent_shading,
                                atol=atol, rtol=rtol)
+
+
+def test_calculate_horizon_band_shading():
+    """Test that calculation of horizon band shading percentage is correct """
+
+    shading_angle = np.array([-10., 0., 3., 9., 20.])
+    horizon_band_angle = 15.
+    percent_shading = calculate_horizon_band_shading(shading_angle,
+                                                     horizon_band_angle)
+    expected_percent_shading = [0., 0., 20., 60., 100.]
+    np.testing.assert_allclose(expected_percent_shading, percent_shading)


### PR DESCRIPTION
- Calculated irradiance values should now be assigned to pvarray's timeseries geometries
- The timeseries geometries should pass the irradiance parameters to the created geometries for each timestep (when using the ``.at(idx)`` methods)
- Switch the engine to using timeseries transform of pvarray by irradiance model (``.transform_ts(pvarray)``)
- Make sure that all the test values stay identical