### PR TITLE
Update engine and run functions for timeseries fast mode

### DIFF
--- a/pvfactors/engine.py
+++ b/pvfactors/engine.py
@@ -227,7 +227,7 @@ class PVEngine(object):
             pvarray.transform(idx)
 
             # Get the irradiance modeling vectors used in final calculations
-            irradiance_vec, rho_vec, invrho_vec, total_perez_vec = \
+            irradiance_vec, _, invrho_vec, _ = \
                 self.irradiance.get_full_modeling_vectors(pvarray, idx)
 
             # Prepare inputs to view factor calculator

--- a/pvfactors/engine.py
+++ b/pvfactors/engine.py
@@ -115,6 +115,86 @@ class PVEngine(object):
         self.skip_step = (solar_zenith > 90) | (DNI < 0) | (DHI < 0) \
             | ((DNI == 0) & (DHI == 0))
 
+    def run_fast_mode(self, fn_build_report=None, pvrow_index=None,
+                      segment_index=None):
+        """Run all simulation timesteps using the fast mode for the back
+        surface of a PV row, and assuming that the incident irradiance on all
+        other surfaces is known (all but back surfaces).
+        The function will return a report that will be built by the function
+        passed by the user.
+
+        Parameters
+        ----------
+        fn_build_report : function, optional
+            Function that will build the report of the simulation
+            (Default value = None)
+        pvrow_index : int, optional
+            Index of the PV row for which we want to calculate back surface
+            irradiance; if used, this will override the
+            ``fast_mode_pvrow_index`` passed at engine initialization
+            (Default = None)
+        segment_index : int, optional
+            Index of the segment on the PV row's back side for which we want
+            to calculate the incident irradiance; if used, this will override
+            the ``fast_mode_segment_index`` passed at engine initialization
+            (Default = None)
+
+        Returns
+        -------
+        report
+            Results from the simulation, as specified by user's report
+            function. If no function is passed, nothing will be returned.
+        """
+
+        # Prepare variables
+        pvrow_idx = self.fast_mode_pvrow_index if pvrow_index is None \
+            else pvrow_index
+        segment_idx = self.fast_mode_segment_index if segment_index is None \
+            else segment_index
+        ts_pvrow = self.pvarray.ts_pvrows[pvrow_idx]
+
+        # Run calculations
+        if segment_idx is None:
+            # Run calculation for all segments of back surface
+            for ts_segment in ts_pvrow.back.list_segments:
+                self._calculate_back_ts_segment_qinc(ts_segment, pvrow_idx)
+        else:
+            # Run calculation for selected segment of back surface
+            ts_segment = ts_pvrow.back.list_segments[segment_idx]
+            self._calculate_back_ts_segment_qinc(ts_segment, pvrow_idx)
+
+        # Create report
+        report = None if fn_build_report is None \
+            else fn_build_report(self.pvarray)
+
+        return report
+
+    def run_full_mode(self, fn_build_report=None):
+        """Run all simulation timesteps using the full mode, which calculates
+        the equilibrium of reflections in the system, and return a report that
+        will be built by the function passed by the user.
+
+        Parameters
+        ----------
+        fn_build_report : function, optional
+            Function that will build the report of the simulation
+            (Default value = None)
+
+        Returns
+        -------
+        report
+            Saved results from the simulation, as specified by user's report
+            function. If no function is passed, nothing will be returned.
+        """
+
+        report = None
+        for idx in tqdm(range(self.n_points)):
+            pvarray = self.run_full_mode_timestep(idx)
+            if fn_build_report is not None:
+                report = fn_build_report(report, pvarray)
+
+        return report
+
     def run_full_mode_timestep(self, idx):
         """Run simulation for a single timestep index and using the full mode,
         which calculates the equilibrium of reflections in the system.
@@ -180,60 +260,21 @@ class PVEngine(object):
 
         return pvarray
 
-    def run_full_mode(self, fn_build_report=None):
-        """Run all simulation timesteps using the full mode, which calculates
-        the equilibrium of reflections in the system, and return a report that
-        will be built by the function passed by the user.
+    def _calculate_back_ts_segment_qinc(self, ts_segment, pvrow_idx):
+        """Calculate the incident irradiance on a timeseries segment's surfaces
+        for the back side of a PV row, using the fast mode, so assuming that
+        the incident irradiance on all other surfaces is known.
+        Nothing is returned by the function, but the segment's surfaces'
+        parameter values are updated.
 
         Parameters
         ----------
-        fn_build_report : function, optional
-            Function that will build the report of the simulation
-            (Default value = None)
-
-        Returns
-        -------
-        report
-            Saved results from the simulation, as specified by user's report
-            function
-
+        ts_segment : :py:class:`~pvfactors.geometry.timeseries.TsDualSegment`
+            Timeseries segment for which we want to calculate the incident
+            irradiance
+        pvrow_idx : int
+            Index of the PV row on which the segment is located
         """
-
-        report = None
-        for idx in tqdm(range(self.n_points)):
-            pvarray = self.run_full_mode_timestep(idx)
-            if fn_build_report is not None:
-                report = fn_build_report(report, pvarray)
-
-        return report
-
-    def run_fast_mode(self, fn_build_report=None, pvrow_index=None,
-                      segment_index=None):
-
-        # Prepare variables
-        pvrow_idx = self.fast_mode_pvrow_index if pvrow_index is None \
-            else pvrow_index
-        segment_idx = self.fast_mode_segment_index if segment_index is None \
-            else segment_index
-        ts_pvrow = self.pvarray.ts_pvrows[pvrow_idx]
-
-        # Run calculations
-        if segment_idx is None:
-            # Run calculation for all segments of back surface
-            for ts_segment in ts_pvrow.back.list_segments:
-                self._calculate_back_ts_segment_qinc(ts_segment, pvrow_idx)
-        else:
-            # Run calculation for selected segment of back surface
-            ts_segment = ts_pvrow.back.list_segments[segment_idx]
-            self._calculate_back_ts_segment_qinc(ts_segment, pvrow_idx)
-
-        # Create report
-        report = None if fn_build_report is None \
-            else fn_build_report(self.pvarray)
-
-        return report
-
-    def _calculate_back_ts_segment_qinc(self, ts_segment, pvrow_idx):
 
         # Get all timeseries surfaces in segment
         list_ts_surfaces = [ts_segment.illum, ts_segment.shaded]

--- a/pvfactors/engine.py
+++ b/pvfactors/engine.py
@@ -230,17 +230,17 @@ class PVEngine(object):
 
         return report
 
-    def run_fast_mode(self, pvrow_idx, segment_idx=None):
+    def run_fast_back_pvrow(self, pvrow_idx, segment_idx=None):
 
         # Calculate irradiance vector for segment
-        albedo = self.irradiance_model.albedo
-        rho_front = self.irradiance_model.rho_front
-        perez_gnd_shaded = None
-        perez_gnd_illum = None
-        perez_pvrow_shaded = None
-        perez_pvrow_illum = None
-        perez_sky = None
-        sky_term = None
+        albedo = self.irradiance.albedo
+        rho_front = self.irradiance.rho_front
+        irr_gnd_shaded = self.irradiance.gnd_shaded
+        irr_gnd_illum = self.irradiance.gnd_illum
+        irr_pvrow_shaded = self.irradiance.pvrow_shaded
+        irr_pvrow_illum = self.irradiance.pvrow_illum
+        irr_sky = self.irradiance.sky_luminance
+        sky_term = 0.
 
         # Calculate view factors for segment
         vf = self.vf_calculator.get_vf_ts_pvrow_segment(
@@ -249,9 +249,11 @@ class PVEngine(object):
             self.pvarray.width)
 
         # Calculate incident irradiance
-        qinc = (vf['to_gnd_shaded'] * albedo * perez_gnd_shaded
-                + vf['to_gnd_illum'] * albedo * perez_gnd_illum
-                + vf['to_pvrow_shaded'] * rho_front * perez_pvrow_shaded
-                + vf['to_pvrow_illum'] * rho_front * perez_pvrow_illum
-                + vf['to_sky'] * perez_sky
+        qinc = (vf['to_gnd_shaded'] * albedo * irr_gnd_shaded
+                + vf['to_gnd_illum'] * albedo * irr_gnd_illum
+                + vf['to_pvrow_shaded'] * rho_front * irr_pvrow_shaded
+                + vf['to_pvrow_illum'] * rho_front * irr_pvrow_illum
+                + vf['to_sky'] * irr_sky
                 + sky_term)
+
+        print(qinc)

--- a/pvfactors/engine.py
+++ b/pvfactors/engine.py
@@ -240,7 +240,10 @@ class PVEngine(object):
         irr_pvrow_shaded = self.irradiance.pvrow_shaded
         irr_pvrow_illum = self.irradiance.pvrow_illum
         irr_sky = self.irradiance.sky_luminance
-        sky_term = 0.
+        # Get the sky term for the segment
+        ts_segment = self.pvarray.ts_pvrows[pvrow_idx] \
+                                 .back.list_segments[segment_idx]
+        sky_term = self.irradiance.get_ts_segment_sky_term_back(ts_segment)
 
         # Calculate view factors for segment
         vf = self.vf_calculator.get_vf_ts_pvrow_segment(

--- a/pvfactors/engine.py
+++ b/pvfactors/engine.py
@@ -235,23 +235,33 @@ class PVEngine(object):
 
         return report
 
-    def run_fast_back_pvrow(self):
+    def run_fast_back_pvrow(self, fn_build_report=None, pvrow_index=None,
+                            segment_index=None):
 
-        pvrow_idx = self.fast_mode_pvrow_index
+        # Prepare variables
+        pvrow_idx = self.fast_mode_pvrow_index if pvrow_index is None \
+            else pvrow_index
+        segment_idx = self.fast_mode_segment_index if segment_index is None \
+            else segment_index
         ts_pvrow = self.pvarray.ts_pvrows[pvrow_idx]
-        if self.fast_mode_segment_index is None:
+
+        # Run calculations
+        if segment_idx is None:
             # Run calculation for all segments of back surface
             for ts_segment in ts_pvrow.back.list_segments:
-                self._update_back_ts_segment_qinc(ts_segment, pvrow_idx)
+                self._calculate_back_ts_segment_qinc(ts_segment, pvrow_idx)
         else:
             # Run calculation for selected segment of back surface
-            ts_segment = ts_pvrow.back.list_segments[
-                self.fast_mode_segment_index]
-            self._update_back_ts_segment_qinc(ts_segment, pvrow_idx)
+            ts_segment = ts_pvrow.back.list_segments[segment_idx]
+            self._calculate_back_ts_segment_qinc(ts_segment, pvrow_idx)
 
-        return self.pvarray
+        # Create report
+        report = None if fn_build_report is None \
+            else fn_build_report(self.pvarray)
 
-    def _update_back_ts_segment_qinc(self, ts_segment, pvrow_idx):
+        return report
+
+    def _calculate_back_ts_segment_qinc(self, ts_segment, pvrow_idx):
 
         # Prepare surfaces of segment
         surface_illum = ts_segment.illum

--- a/pvfactors/engine.py
+++ b/pvfactors/engine.py
@@ -110,7 +110,7 @@ class PVEngine(object):
                             surface_tilt, surface_azimuth, albedo, GHI=GHI)
 
         # Add timeseries irradiance results to pvarray
-        self.irradiance.transform_ts(self.pvarray)
+        self.irradiance.transform(self.pvarray)
 
         # Skip timesteps when:
         #    - solar zenith > 90, ie the sun is down

--- a/pvfactors/engine.py
+++ b/pvfactors/engine.py
@@ -229,3 +229,29 @@ class PVEngine(object):
                 report = fn_build_report(report, pvarray)
 
         return report
+
+    def run_fast_mode(self, pvrow_idx, segment_idx=None):
+
+        # Calculate irradiance vector for segment
+        albedo = self.irradiance_model.albedo
+        rho_front = self.irradiance_model.rho_front
+        perez_gnd_shaded = None
+        perez_gnd_illum = None
+        perez_pvrow_shaded = None
+        perez_pvrow_illum = None
+        perez_sky = None
+        sky_term = None
+
+        # Calculate view factors for segment
+        vf = self.vf_calculator.get_vf_ts_pvrow_segment(
+            pvrow_idx, segment_idx, self.pvarray.ts_pvrows,
+            self.pvarray.ts_ground, self.pvarray.rotation_vec,
+            self.pvarray.width)
+
+        # Calculate incident irradiance
+        qinc = (vf['to_gnd_shaded'] * albedo * perez_gnd_shaded
+                + vf['to_gnd_illum'] * albedo * perez_gnd_illum
+                + vf['to_pvrow_shaded'] * rho_front * perez_pvrow_shaded
+                + vf['to_pvrow_illum'] * rho_front * perez_pvrow_illum
+                + vf['to_sky'] * perez_sky
+                + sky_term)

--- a/pvfactors/engine.py
+++ b/pvfactors/engine.py
@@ -259,4 +259,6 @@ class PVEngine(object):
                 + vf['to_sky'] * irr_sky
                 + sky_term)
 
-        print(qinc)
+        qinc = np.where(self.skip_step, 0., qinc)
+
+        return qinc

--- a/pvfactors/engine.py
+++ b/pvfactors/engine.py
@@ -310,7 +310,8 @@ class PVEngine(object):
              'reflection_pvrow_shaded': pvrow_shadow_refl,
              'reflection_pvrow_illum': pvrow_illum_refl,
              'isotropic': isotropic,
-             'reflection': reflections})
+             'reflection': reflections,
+             'view_factors': vf_illum})
 
         # Calculate incident irradiance on shaded surface
         gnd_shadow_refl = vf_shaded['to_gnd_shaded'] * albedo * irr_gnd_shaded
@@ -332,4 +333,5 @@ class PVEngine(object):
              'reflection_pvrow_shaded': pvrow_shadow_refl,
              'reflection_pvrow_illum': pvrow_illum_refl,
              'isotropic': isotropic,
-             'reflection': reflections})
+             'reflection': reflections,
+             'view_factors': vf_shaded})

--- a/pvfactors/geometry/pvarray.py
+++ b/pvfactors/geometry/pvarray.py
@@ -2,7 +2,6 @@
 geometries."""
 
 import numpy as np
-from pvfactors.geometry.pvground import PVGround
 from pvfactors.config import X_ORIGIN_PVROWS, VIEW_DICT, DISTANCE_TOLERANCE
 from pvfactors.geometry.base import \
     _get_solar_2d_vectors, BasePVArray, _get_rotation_from_tilt_azimuth

--- a/pvfactors/geometry/timeseries.py
+++ b/pvfactors/geometry/timeseries.py
@@ -981,6 +981,16 @@ class TsSurface(object):
         """Timeseries length of the surface"""
         return self.coords.length
 
+    @property
+    def highest_point(self):
+        """Timeseries point coordinates of highest point of surface"""
+        return self.coords.highest_point
+
+    @property
+    def lowest_point(self):
+        """Timeseries point coordinates of lowest point of surface"""
+        return self.coords.lowest_point
+
 
 class TsLineCoords(object):
     """Timeseries line coordinates class: will provide a helpful shapely-like

--- a/pvfactors/irradiance/base.py
+++ b/pvfactors/irradiance/base.py
@@ -92,3 +92,17 @@ class BaseModel(object):
             total_perez_vec.append(surface.get_param('total_perez'))
 
         return irradiance_vec, rho_vec, invrho_vec, total_perez_vec
+
+    def get_ts_segment_sky_term_back(self, ts_segment):
+
+        # Calculate sky term for each surface of the segment
+        value_illum = 0.
+        value_shaded = 0.
+        for component in self.irradiance_comp:
+            value_illum += ts_segment.illum.get_param(component)
+            value_shaded += ts_segment.shaded.get_param(component)
+        ts_segment.illum.update_params({'sky_term': value_illum})
+        ts_segment.shaded.update_params({'sky_term': value_shaded})
+
+        # Return the weighted value of sky term
+        return ts_segment.get_param_weighted('sky_term')

--- a/pvfactors/irradiance/base.py
+++ b/pvfactors/irradiance/base.py
@@ -28,6 +28,31 @@ class BaseModel(object):
         """Not implemented"""
         raise NotImplementedError
 
+    @property
+    def gnd_shaded(self):
+        """Not implemented"""
+        raise NotImplementedError
+
+    @property
+    def gnd_illum(self):
+        """Not implemented"""
+        raise NotImplementedError
+
+    @property
+    def pvrow_shaded(self):
+        """Not implemented"""
+        raise NotImplementedError
+
+    @property
+    def pvrow_illum(self):
+        """Not implemented"""
+        raise NotImplementedError
+
+    @property
+    def sky(self):
+        """Not implemented"""
+        raise NotImplementedError
+
     def get_modeling_vectors(self, pvarray):
         """Get vector of summed up irradiance values from a PV array, as well
         as the inverse reflectivity values (the latter need to be named

--- a/pvfactors/irradiance/base.py
+++ b/pvfactors/irradiance/base.py
@@ -93,16 +93,9 @@ class BaseModel(object):
 
         return irradiance_vec, rho_vec, invrho_vec, total_perez_vec
 
-    def get_ts_segment_sky_term_back(self, ts_segment):
+    def update_ts_surface_sky_term(self, ts_surface, name_sky_term='sky_term'):
 
-        # Calculate sky term for each surface of the segment
-        value_illum = 0.
-        value_shaded = 0.
+        value = 0.
         for component in self.irradiance_comp:
-            value_illum += ts_segment.illum.get_param(component)
-            value_shaded += ts_segment.shaded.get_param(component)
-        ts_segment.illum.update_params({'sky_term': value_illum})
-        ts_segment.shaded.update_params({'sky_term': value_shaded})
-
-        # Return the weighted value of sky term
-        return ts_segment.get_param_weighted('sky_term')
+            value += ts_surface.get_param(component)
+        ts_surface.update_params({name_sky_term: value})

--- a/pvfactors/irradiance/base.py
+++ b/pvfactors/irradiance/base.py
@@ -94,7 +94,16 @@ class BaseModel(object):
         return irradiance_vec, rho_vec, invrho_vec, total_perez_vec
 
     def update_ts_surface_sky_term(self, ts_surface, name_sky_term='sky_term'):
+        """Update the 'sky_term' parameter of a timeseries surface.
 
+        Parameters
+        ----------
+        ts_surface :  :py:class:`~pvfactors.geometry.timeseries.TsSurface`
+            Timeseries surface whose 'sky_term' parameter value we want to
+            update
+        name_sky_term : str, optional
+            Name of the sky term parameter (Default = 'sky_term')
+        """
         value = 0.
         for component in self.irradiance_comp:
             value += ts_surface.get_param(component)

--- a/pvfactors/irradiance/models.py
+++ b/pvfactors/irradiance/models.py
@@ -814,3 +814,30 @@ class HybridPerezOrdered(BaseModel):
         return luminance_isotropic, luminance_circumsolar, poa_horizon, \
             poa_circumsolar_front, poa_circumsolar_back, \
             aoi_front_pvrow, aoi_back_pvrow
+
+    @property
+    def gnd_shaded(self):
+        """Total timeseries irradiance incident on ground shaded areas"""
+        return self.total_perez['ground_shaded']
+
+    @property
+    def gnd_illum(self):
+        """Total timeseries irradiance incident on ground illuminated areas"""
+        return self.total_perez['ground_illum']
+
+    @property
+    def pvrow_shaded(self):
+        """Total timeseries irradiance incident on PV row's front illuminated
+        areas and calculated by Perez transposition"""
+        return self.total_perez['front_shaded_pvrow']
+
+    @property
+    def pvrow_illum(self):
+        """Total timeseries irradiance incident on PV row's front shaded
+        areas and calculated by Perez transposition"""
+        return self.total_perez['front_illum_pvrow']
+
+    @property
+    def sky_luminance(self):
+        """Total timeseries isotropic luminance of sky"""
+        return self.isotropic_luminance

--- a/pvfactors/irradiance/models.py
+++ b/pvfactors/irradiance/models.py
@@ -79,18 +79,14 @@ class IsotropicOrdered(BaseModel):
             solar_azimuth = np.array([solar_azimuth])
             surface_tilt = np.array([surface_tilt])
             surface_azimuth = np.array([surface_azimuth])
-            if GHI is not None:
-                GHI = np.array([GHI])
+            GHI = None if GHI is None else np.array([GHI])
         # Length of arrays
         n = len(DNI)
         # Make sure that albedo is a vector
-        if np.isscalar(albedo):
-            albedo = albedo * np.ones(n)
+        albedo = albedo * np.ones(n) if np.isscalar(albedo) else albedo
 
         # Save and calculate total POA values from Perez model
-        if GHI is None:
-            # Calculate GHI if not specified
-            GHI = DNI * cosd(solar_zenith) + DHI
+        GHI = DNI * cosd(solar_zenith) + DHI if GHI is None else GHI
         self.GHI = GHI
         self.DHI = DHI
         self.n_steps = n
@@ -349,13 +345,11 @@ class HybridPerezOrdered(BaseModel):
             solar_azimuth = np.array([solar_azimuth])
             surface_tilt = np.array([surface_tilt])
             surface_azimuth = np.array([surface_azimuth])
-            if GHI is not None:
-                GHI = np.array([GHI])
+            GHI = None if GHI is None else np.array([GHI])
         # Length of arrays
         n = len(DNI)
         # Make sure that albedo is a vector
-        if np.isscalar(albedo):
-            albedo = albedo * np.ones(n)
+        albedo = albedo * np.ones(n) if np.isscalar(albedo) else albedo
 
         # Calculate terms from Perez model
         luminance_isotropic, luminance_circumsolar, poa_horizon, \
@@ -366,9 +360,7 @@ class HybridPerezOrdered(BaseModel):
                 surface_tilt, surface_azimuth)
 
         # Save and calculate total POA values from Perez model
-        if GHI is None:
-            # Calculate GHI if not specified
-            GHI = DNI * cosd(solar_zenith) + DHI
+        GHI = DNI * cosd(solar_zenith) + DHI if GHI is None else GHI
         self.GHI = GHI
         self.DHI = DHI
         self.n_steps = n

--- a/pvfactors/irradiance/models.py
+++ b/pvfactors/irradiance/models.py
@@ -114,57 +114,6 @@ class IsotropicOrdered(BaseModel):
             ~front_is_illum, DNI * cosd(aoi_back_pvrow), 0.)
         self.total_perez['front_pvrow'] = perez_front_pvrow['poa_global']
 
-    def transform(self, pvarray, idx=0):
-        """Apply calculated irradiance values to PV array.
-
-        Parameters
-        ----------
-        pvarray : PV array object
-            PV array on which the calculated irradiance values will be applied
-        idx : int, optional
-            Index of the irradiance values to apply to the PV array (in the
-            whole timeseries values)
-        """
-
-        for seg in pvarray.ground.list_segments:
-            seg.illum_collection.update_params(
-                {'direct': self.direct['ground'][idx],
-                 'rho': self.albedo[idx],
-                 'inv_rho': 1. / self.albedo[idx],
-                 'total_perez': self.GHI[idx]})
-            seg.shaded_collection.update_params(
-                {'direct': 0.,
-                 'rho': self.albedo[idx],
-                 'inv_rho': 1. / self.albedo[idx],
-                 'total_perez': self.DHI[idx]})
-
-        for pvrow in pvarray.pvrows:
-            # Front
-            for seg in pvrow.front.list_segments:
-                seg.illum_collection.update_params(
-                    {'direct': self.direct['front_pvrow'][idx],
-                     'rho': self.rho_front,
-                     'inv_rho': 1. / self.rho_front,
-                     'total_perez': self.total_perez['front_pvrow'][idx]})
-                seg.shaded_collection.update_params(
-                    {'direct': 0.,
-                     'rho': self.rho_front,
-                     'inv_rho': 1. / self.rho_front,
-                     'total_perez': self.total_perez['front_pvrow'][idx] -
-                     self.direct['front_pvrow'][idx]})
-            # Back
-            for seg in pvrow.back.list_segments:
-                seg.illum_collection.update_params(
-                    {'direct': self.direct['back_pvrow'][idx],
-                     'rho': self.rho_back,
-                     'inv_rho': 1. / self.rho_back,
-                     'total_perez': 0.})
-                seg.shaded_collection.update_params(
-                    {'direct': 0.,
-                     'rho': self.rho_back,
-                     'inv_rho': 1. / self.rho_back,
-                     'total_perez': 0.})
-
     def transform_ts(self, pvarray):
         """Apply calculated irradiance values to PV array timeseries
         geometries: assign values as parameters to timeseries surfaces.
@@ -187,12 +136,12 @@ class IsotropicOrdered(BaseModel):
             {'direct': self.direct['ground'],
              'rho': self.albedo,
              'inv_rho': 1. / self.albedo,
-             'total_perez': self.GHI})
+             'total_perez': self.gnd_illum})
         pvarray.ts_ground.shaded_params.update(
             {'direct': np.zeros(n_steps),
              'rho': self.albedo,
              'inv_rho': 1. / self.albedo,
-             'total_perez': self.DHI})
+             'total_perez': self.gnd_shaded})
 
         for ts_pvrow in pvarray.ts_pvrows:
             # Front
@@ -201,13 +150,12 @@ class IsotropicOrdered(BaseModel):
                     {'direct': self.direct['front_pvrow'],
                      'rho': rho_front,
                      'inv_rho': inv_rho_front,
-                     'total_perez': self.total_perez['front_pvrow']})
+                     'total_perez': self.pvrow_illum})
                 ts_seg.shaded.update_params(
                     {'direct': np.zeros(n_steps),
                      'rho': rho_front,
                      'inv_rho': inv_rho_front,
-                     'total_perez': self.total_perez['front_pvrow']
-                     - self.direct['front_pvrow']})
+                     'total_perez': self.pvrow_shaded})
             # Back
             for ts_seg in ts_pvrow.back.list_segments:
                 ts_seg.illum.update_params(
@@ -257,6 +205,33 @@ class IsotropicOrdered(BaseModel):
 
         return np.array(irradiance_vec), np.array(rho_vec), \
             np.array(inv_rho_vec), np.array(total_perez_vec)
+
+    @property
+    def gnd_shaded(self):
+        """Total timeseries irradiance incident on ground shaded areas"""
+        return self.DHI
+
+    @property
+    def gnd_illum(self):
+        """Total timeseries irradiance incident on ground illuminated areas"""
+        return self.GHI
+
+    @property
+    def pvrow_shaded(self):
+        """Total timeseries irradiance incident on PV row's front illuminated
+        areas and calculated by Perez transposition"""
+        return self.pvrow_illum - self.direct['front_pvrow']
+
+    @property
+    def pvrow_illum(self):
+        """Total timeseries irradiance incident on PV row's front shaded
+        areas and calculated by Perez transposition"""
+        return self.total_perez['front_pvrow']
+
+    @property
+    def sky_luminance(self):
+        """Total timeseries isotropic luminance of sky"""
+        return self.isotropic_luminance
 
 
 class HybridPerezOrdered(BaseModel):
@@ -355,7 +330,7 @@ class HybridPerezOrdered(BaseModel):
         luminance_isotropic, luminance_circumsolar, poa_horizon, \
             poa_circumsolar_front, poa_circumsolar_back, \
             aoi_front_pvrow, aoi_back_pvrow = \
-            self.calculate_luminance_poa_components(
+            self._calculate_luminance_poa_components(
                 timestamps, DNI, DHI, solar_zenith, solar_azimuth,
                 surface_tilt, surface_azimuth)
 
@@ -423,14 +398,14 @@ class HybridPerezOrdered(BaseModel):
             'horizon': np.zeros(n_steps),
             'rho': self.albedo,
             'inv_rho': 1. / self.albedo,
-            'total_perez': self.total_perez['ground_illum']})
+            'total_perez': self.gnd_illum})
         pvarray.ts_ground.shaded_params.update({
             'direct': np.zeros(n_steps),
             'circumsolar': np.zeros(n_steps),
             'horizon': np.zeros(n_steps),
             'rho': self.albedo,
             'inv_rho': 1. / self.albedo,
-            'total_perez': self.total_perez['ground_shaded']})
+            'total_perez': self.gnd_shaded})
 
         # Transform timeseries PV rows
         for idx_pvrow, ts_pvrow in enumerate(ts_pvrows):
@@ -442,19 +417,19 @@ class HybridPerezOrdered(BaseModel):
                     'horizon': self.horizon['front_pvrow'],
                     'rho': rho_front,
                     'inv_rho': inv_rho_front,
-                    'total_perez': self.total_perez['front_illum_pvrow']})
+                    'total_perez': self.pvrow_illum})
                 ts_seg.shaded.update_params({
                     'direct': np.zeros(n_steps),
                     'circumsolar': np.zeros(n_steps),
                     'horizon': self.horizon['front_pvrow'],
                     'rho': rho_front,
                     'inv_rho': inv_rho_front,
-                    'total_perez': self.total_perez['front_shaded_pvrow']})
+                    'total_perez': self.pvrow_shaded})
             # Back: apply back surface horizon shading
             for ts_seg in ts_pvrow.back.list_segments:
                 # Illum
                 centroid_illum = ts_seg.illum.centroid
-                hor_shd_pct_illum = self.calculate_horizon_shading_pct_ts(
+                hor_shd_pct_illum = self._calculate_horizon_shading_pct_ts(
                     ts_pvrows, centroid_illum, idx_pvrow, tilted_to_left,
                     is_back_side=True)
                 ts_seg.illum.update_params({
@@ -469,7 +444,7 @@ class HybridPerezOrdered(BaseModel):
                     'total_perez': np.zeros(n_steps)})
                 # Back
                 centroid_shaded = ts_seg.shaded.centroid
-                hor_shd_pct_shaded = self.calculate_horizon_shading_pct_ts(
+                hor_shd_pct_shaded = self._calculate_horizon_shading_pct_ts(
                     ts_pvrows, centroid_shaded, idx_pvrow, tilted_to_left,
                     is_back_side=True)
                 ts_seg.shaded.update_params({
@@ -482,85 +457,6 @@ class HybridPerezOrdered(BaseModel):
                     'rho': rho_back,
                     'inv_rho': inv_rho_back,
                     'total_perez': np.zeros(n_steps)})
-
-    def transform(self, pvarray, idx=0):
-        """Apply calculated irradiance values to PV array, as well as
-        horizon band shading on pvrow back sides.
-
-        Parameters
-        ----------
-        pvarray : PV array object
-            PV array on which the calculated irradiance values will be applied
-        idx : int, optional
-            Index of the irradiance values to apply to the PV array (in the
-            whole timeseries values)
-        """
-
-        for seg in pvarray.ground.list_segments:
-            seg.illum_collection.update_params(
-                {'direct': self.direct['ground'][idx],
-                 'circumsolar': self.circumsolar['ground'][idx],
-                 'horizon': 0.,
-                 'rho': self.albedo[idx],
-                 'inv_rho': 1. / self.albedo[idx],
-                 'total_perez': self.total_perez['ground_illum'][idx]})
-            seg.shaded_collection.update_params(
-                {'direct': 0.,
-                 'circumsolar': 0.,
-                 'horizon': 0.,
-                 'rho': self.albedo[idx],
-                 'inv_rho': 1. / self.albedo[idx],
-                 'total_perez': self.total_perez['ground_shaded'][idx]})
-
-        pvrows = pvarray.pvrows
-        for idx_pvrow, pvrow in enumerate(pvrows):
-            # Front
-            for seg in pvrow.front.list_segments:
-                seg.illum_collection.update_params(
-                    {'direct': self.direct['front_pvrow'][idx],
-                     'circumsolar': self.circumsolar['front_pvrow'][idx],
-                     'horizon': self.horizon['front_pvrow'][idx],
-                     'rho': self.rho_front,
-                     'inv_rho': 1. / self.rho_front,
-                     'total_perez':
-                     self.total_perez['front_illum_pvrow'][idx]})
-                seg.shaded_collection.update_params(
-                    {'direct': 0.,
-                     'circumsolar': 0.,
-                     'horizon': self.horizon['front_pvrow'][idx],
-                     'rho': self.rho_front,
-                     'inv_rho': 1. / self.rho_front,
-                     'total_perez':
-                     self.total_perez['front_shaded_pvrow'][idx]})
-            # Back: apply back surface horizon shading
-            for seg in pvrow.back.list_segments:
-                # Illum
-                idx_neighbor = pvarray.back_neighbors[idx_pvrow]
-                for surf in seg.illum_collection.list_surfaces:
-                    hor_shd_pct = self.calculate_horizon_shading_pct(
-                        surf, idx_neighbor, pvrows)
-                    surf.update_params(
-                        {'direct': self.direct['back_pvrow'][idx],
-                         'circumsolar': self.circumsolar['back_pvrow'][idx],
-                         'horizon': self.horizon['back_pvrow'][idx] *
-                         (1. - hor_shd_pct / 100.),
-                         'horizon_shd_pct': hor_shd_pct,
-                         'rho': self.rho_back,
-                         'inv_rho': 1. / self.rho_back,
-                         'total_perez': 0.})
-                # Shaded
-                for surf in seg.shaded_collection.list_surfaces:
-                    hor_shd_pct = self.calculate_horizon_shading_pct(
-                        surf, idx_neighbor, pvrows)
-                    surf.update_params(
-                        {'direct': 0.,
-                         'circumsolar': 0.,
-                         'horizon': self.horizon['back_pvrow'][idx] *
-                         (1. - hor_shd_pct / 100.),
-                         'horizon_shd_pct': hor_shd_pct,
-                         'rho': self.rho_back,
-                         'inv_rho': 1. / self.rho_back,
-                         'total_perez': 0.})
 
     def get_full_modeling_vectors(self, pvarray, idx):
         """Get the modeling vectors used in matrix calculations of mathematical
@@ -600,44 +496,36 @@ class HybridPerezOrdered(BaseModel):
         return np.array(irradiance_vec), np.array(rho_vec), \
             np.array(inv_rho_vec), np.array(total_perez_vec)
 
-    def calculate_horizon_shading_pct(self, surface, idx_neighbor, pvrows):
-        """Calculate horizon band shading percentage on surfaces of the ordered
-        PV array.
-        TODO: This needs to be merged with circumsolar shading for performance
+    @property
+    def gnd_shaded(self):
+        """Total timeseries irradiance incident on ground shaded areas"""
+        return self.total_perez['ground_shaded']
 
-        Parameters
-        ----------
-        surface : :py:class:`~pvfactors.geometry.base.PVSurface` object
-            PV surface for which some horizon band shading will occur
-        idx_neighbor : int
-            Index of the neighboring PV row (can be ``None``)
-        pvrows : list of :py:class:`~pvfactors.geometry.pvrow.PVRow` objects
-            List of PV rows on which ``idx_neighbor`` will be used
+    @property
+    def gnd_illum(self):
+        """Total timeseries irradiance incident on ground illuminated areas"""
+        return self.total_perez['ground_illum']
 
-        Returns
-        -------
-        horizon_shading_pct : float
-            Percentage of horizon band irradiance shaded (from 0 to 100)
-        """
+    @property
+    def pvrow_shaded(self):
+        """Total timeseries irradiance incident on PV row's front illuminated
+        areas and calculated by Perez transposition"""
+        return self.total_perez['front_shaded_pvrow']
 
-        # TODO: should be applied to all pvrow surfaces
+    @property
+    def pvrow_illum(self):
+        """Total timeseries irradiance incident on PV row's front shaded
+        areas and calculated by Perez transposition"""
+        return self.total_perez['front_illum_pvrow']
 
-        horizon_shading_pct = 0.
-        if idx_neighbor is not None:
-            centroid = surface.centroid
-            neighbor_point = pvrows[idx_neighbor].highest_point
-            shading_angle = np.abs(np.arctan(
-                (neighbor_point.y - centroid.y) /
-                (neighbor_point.x - centroid.x))
-            ) * 180. / np.pi
-            horizon_shading_pct = calculate_horizon_band_shading(
-                shading_angle, self.horizon_band_angle)
+    @property
+    def sky_luminance(self):
+        """Total timeseries isotropic luminance of sky"""
+        return self.isotropic_luminance
 
-        return horizon_shading_pct
-
-    def calculate_horizon_shading_pct_ts(self, ts_pvrows, ts_point_coords,
-                                         pvrow_idx, tilted_to_left,
-                                         is_back_side=True):
+    def _calculate_horizon_shading_pct_ts(self, ts_pvrows, ts_point_coords,
+                                          pvrow_idx, tilted_to_left,
+                                          is_back_side=True):
         """Calculate horizon band shading percentage on surfaces of the ordered
         PV array, in a vectorized way.
 
@@ -692,8 +580,8 @@ class HybridPerezOrdered(BaseModel):
 
         return shading_pct
 
-    def calculate_circumsolar_shading_pct(self, surface, idx_neighbor, pvrows,
-                                          solar_2d_vector):
+    def _calculate_circumsolar_shading_pct(self, surface, idx_neighbor, pvrows,
+                                           solar_2d_vector):
         """Model method to calculate circumsolar shading on surfaces of
         the ordered PV array.
         TODO: This needs to be merged with horizon shading for performance
@@ -737,7 +625,7 @@ class HybridPerezOrdered(BaseModel):
         return circ_shading_pct
 
     @staticmethod
-    def calculate_luminance_poa_components(
+    def _calculate_luminance_poa_components(
             timestamps, DNI, DHI, solar_zenith, solar_azimuth, surface_tilt,
             surface_azimuth):
         """Calculate Perez-like luminance and plane-of-array irradiance values.
@@ -806,30 +694,3 @@ class HybridPerezOrdered(BaseModel):
         return luminance_isotropic, luminance_circumsolar, poa_horizon, \
             poa_circumsolar_front, poa_circumsolar_back, \
             aoi_front_pvrow, aoi_back_pvrow
-
-    @property
-    def gnd_shaded(self):
-        """Total timeseries irradiance incident on ground shaded areas"""
-        return self.total_perez['ground_shaded']
-
-    @property
-    def gnd_illum(self):
-        """Total timeseries irradiance incident on ground illuminated areas"""
-        return self.total_perez['ground_illum']
-
-    @property
-    def pvrow_shaded(self):
-        """Total timeseries irradiance incident on PV row's front illuminated
-        areas and calculated by Perez transposition"""
-        return self.total_perez['front_shaded_pvrow']
-
-    @property
-    def pvrow_illum(self):
-        """Total timeseries irradiance incident on PV row's front shaded
-        areas and calculated by Perez transposition"""
-        return self.total_perez['front_illum_pvrow']
-
-    @property
-    def sky_luminance(self):
-        """Total timeseries isotropic luminance of sky"""
-        return self.isotropic_luminance

--- a/pvfactors/irradiance/models.py
+++ b/pvfactors/irradiance/models.py
@@ -114,7 +114,7 @@ class IsotropicOrdered(BaseModel):
             ~front_is_illum, DNI * cosd(aoi_back_pvrow), 0.)
         self.total_perez['front_pvrow'] = perez_front_pvrow['poa_global']
 
-    def transform_ts(self, pvarray):
+    def transform(self, pvarray):
         """Apply calculated irradiance values to PV array timeseries
         geometries: assign values as parameters to timeseries surfaces.
 
@@ -372,7 +372,7 @@ class HybridPerezOrdered(BaseModel):
         self.total_perez['ground_illum'] = GHI
         self.total_perez['sky'] = luminance_isotropic
 
-    def transform_ts(self, pvarray):
+    def transform(self, pvarray):
         """Apply calculated irradiance values to PV array timeseries
         geometries: assign values as parameters to timeseries surfaces.
 

--- a/pvfactors/report.py
+++ b/pvfactors/report.py
@@ -6,8 +6,8 @@ import numpy as np
 
 def example_fn_build_report(report, pvarray):
     """Example function that builds a report when used in the
-    :py:class:`~pvfactors.engine.PVEngine`. Here it will be a dictionary
-    with lists of calculated values.
+    :py:class:`~pvfactors.engine.PVEngine` with full mode simulations.
+    Here it will be a dictionary with lists of calculated values.
 
     Parameters
     ----------
@@ -44,6 +44,13 @@ def example_fn_build_report(report, pvarray):
         report['iso_back'].append(np.nan)
 
     return report
+
+
+def example_fn_build_report_fast_mode(pvarray):
+
+    ts_pvrow = pvarray.ts_pvrows[1]
+    qinc_back = ts_pvrow.back.get_param_weighted('qinc')
+    return qinc_back
 
 
 class ExampleReportBuilder(object):

--- a/pvfactors/report.py
+++ b/pvfactors/report.py
@@ -46,13 +46,6 @@ def example_fn_build_report(report, pvarray):
     return report
 
 
-def example_fn_build_report_fast_mode(pvarray):
-
-    ts_pvrow = pvarray.ts_pvrows[1]
-    qinc_back = ts_pvrow.back.get_param_weighted('qinc')
-    return qinc_back
-
-
 class ExampleReportBuilder(object):
     """A class is required to build reports when running calculations with
     multiprocessing because of python constraints"""

--- a/pvfactors/tests/test_engine.py
+++ b/pvfactors/tests/test_engine.py
@@ -145,3 +145,39 @@ def test_fast_pvengine_float_inputs_perez(params):
     assert isinstance(pvarray, OrderedPVArray)
     np.testing.assert_almost_equal(
         pvarray.pvrows[1].back.get_param_weighted('qinc'), 123.7087347744459)
+
+
+def test_run_fast_mode(params):
+    """Test that PV engine works for float inputs"""
+
+    # Prepare some engine inputs
+    irradiance_model = HybridPerezOrdered()
+    pvarray = OrderedPVArray.init_from_dict(
+        params, param_names=irradiance_model.params)
+    fast_mode_pvrow_index = 1
+
+    # Create engine object
+    eng = PVEngine(pvarray, irradiance_model=irradiance_model,
+                   fast_mode_pvrow_index=fast_mode_pvrow_index)
+
+    # Irradiance inputs
+    timestamps = dt.datetime(2019, 6, 11, 11)
+    DNI = 1000.
+    DHI = 100.
+
+    # Fit engine
+    eng.fit(timestamps, DNI, DHI,
+            params['solar_zenith'], params['solar_azimuth'],
+            params['surface_tilt'], params['surface_azimuth'],
+            params['rho_ground'])
+    # Checks
+    np.testing.assert_almost_equal(eng.irradiance.direct['front_pvrow'], DNI)
+
+    # Run fast mode
+    pvrow_idx = 1
+    segment_idx = 0
+    eng.run_fast_mode(pvrow_idx, segment_idx=segment_idx)
+    # # Checks
+    # assert isinstance(pvarray, OrderedPVArray)
+    # np.testing.assert_almost_equal(
+    #     pvarray.pvrows[1].back.get_param_weighted('qinc'), 123.7087347744459)

--- a/pvfactors/tests/test_engine.py
+++ b/pvfactors/tests/test_engine.py
@@ -191,15 +191,49 @@ def test_run_fast_mode(params):
     # Check results
     np.testing.assert_allclose(qinc, 123.753462)
 
-    # Check the left pv row back side (no obstruction)
-    # This is exactly the same calculated value as in loop-like fast mode
-    # because ground is not infinite for back of left pv row
+
+def test_run_fast_mode_compare_to_loop_like(params):
+    """Test that PV engine works for timeseries fast mode and float inputs.
+
+    Check the left pv row back side (no obstruction, since rotation < 0)
+    This should be exactly the same calculated value as in loop-like fast mode
+    because ground is not infinite for back of left pv row"""
+
+    # Prepare some engine inputs
+    irradiance_model = HybridPerezOrdered()
+    pvarray = OrderedPVArray.init_from_dict(
+        params, param_names=irradiance_model.params)
+    fast_mode_pvrow_index = 1
+    fast_mode_segment_index = 0
+    # Irradiance inputs
+    timestamps = dt.datetime(2019, 6, 11, 11)
+    DNI = 1000.
+    DHI = 100.
+
+    # Create engine object
+    eng = PVEngine(pvarray, irradiance_model=irradiance_model,
+                   fast_mode_pvrow_index=fast_mode_pvrow_index)
+    # Fit engine
+    eng.fit(timestamps, DNI, DHI,
+            params['solar_zenith'], params['solar_azimuth'],
+            params['surface_tilt'], params['surface_azimuth'],
+            params['rho_ground'])
+
+    # Run baseline calculation
+    pvrow_idx = 0
+    time_idx = 0
+    pvarray_loop = _fast_mode_with_loop(eng.pvarray, eng.irradiance,
+                                        eng.vf_calculator, pvrow_idx,
+                                        time_idx)
+    # Expected should be: 138.10421248631152
+    qinc_expected = pvarray_loop.pvrows[0].back.get_param_weighted('qinc')
+    # Run timeseries calculation
     qinc = eng.run_fast_back_pvrow(
         fn_build_report=lambda pvarray: (pvarray.ts_pvrows[0]
                                          .back.get_param_weighted('qinc')),
         pvrow_index=0)
     # Check results: value taken from loop-like fast mode
-    np.testing.assert_allclose(qinc, 138.10421248631152)
+    np.testing.assert_allclose(qinc, qinc_expected)
 
 
 def test_run_fast_mode_back_shading(params):
@@ -277,3 +311,50 @@ def test_fast_mode_8760(params, df_inputs_clearsky_8760):
 
     # Check than annual energy on back is consistent
     np.testing.assert_allclose(np.nansum(qinc) / 1e3, 349.9345317405013)
+
+
+def _fast_mode_with_loop(pvarray, irradiance, vf_calculator, pvrow_idx, idx):
+    """Function for running fast mode using subset of view factor matrix
+    and with the shapely geometries.
+
+    Saving this for future debugging of new timeseries fast mode.
+    """
+    # Transform pvarray to time step
+    pvarray.transform(idx)
+
+    # Apply irradiance terms to pvarray
+    irradiance_vec, rho_vec, invrho_vec, total_perez_vec = \
+        irradiance.get_full_modeling_vectors(pvarray, idx)
+
+    # Prepare inputs to view factor calculator
+    geom_dict = pvarray.dict_surfaces
+    view_matrix, obstr_matrix = pvarray.view_obstr_matrices
+
+    # Indices of the surfaces of the back of the selected pvrows
+    list_surface_indices = pvarray.pvrows[pvrow_idx].back.surface_indices
+
+    # Calculate view factors using a subset of view_matrix to
+    # gain in calculation speed
+    vf_matrix_subset = vf_calculator.get_vf_matrix_subset(
+        geom_dict, view_matrix, obstr_matrix, pvarray.pvrows,
+        list_surface_indices)
+    pvarray.vf_matrix = vf_matrix_subset
+
+    irradiance_vec_subset = irradiance_vec[list_surface_indices]
+    # In fast mode, will not care to calculate q0
+    qinc = vf_matrix_subset.dot(rho_vec * total_perez_vec) \
+        + irradiance_vec_subset
+
+    # Calculate other terms
+    isotropic_vec = vf_matrix_subset[:, -1] * total_perez_vec[-1]
+    reflection_vec = qinc - irradiance_vec_subset \
+        - isotropic_vec
+
+    # Update selected surfaces with values
+    for i, surf_idx in enumerate(list_surface_indices):
+        surface = geom_dict[surf_idx]
+        surface.update_params({'qinc': qinc[i],
+                               'isotropic': isotropic_vec[i],
+                               'reflection': reflection_vec[i]})
+
+    return pvarray

--- a/pvfactors/tests/test_engine.py
+++ b/pvfactors/tests/test_engine.py
@@ -156,6 +156,7 @@ def test_run_fast_mode(params):
     pvarray = OrderedPVArray.init_from_dict(
         params, param_names=irradiance_model.params)
     fast_mode_pvrow_index = 1
+    fast_mode_segment_index = 0
 
     # Create engine object
     eng = PVEngine(pvarray, irradiance_model=irradiance_model,
@@ -175,19 +176,17 @@ def test_run_fast_mode(params):
     np.testing.assert_almost_equal(eng.irradiance.direct['front_pvrow'], DNI)
 
     # Run fast mode
-    pvrow_idx = 1
-
-    # By providing segment index
-    segment_idx = 0
-    pvarray = eng.run_fast_back_pvrow(pvrow_idx, segment_idx=segment_idx)
-    ts_seg = pvarray.ts_pvrows[pvrow_idx].back.list_segments[segment_idx]
+    pvarray = eng.run_fast_back_pvrow()
+    ts_seg = (pvarray.ts_pvrows[fast_mode_pvrow_index]
+              .back.list_segments[fast_mode_segment_index])
     qinc = ts_seg.get_param_weighted('qinc')
     # Check results
     np.testing.assert_allclose(qinc, 123.753462)
 
     # Without providing segment index
-    pvarray = eng.run_fast_back_pvrow(pvrow_idx)
-    ts_side = pvarray.ts_pvrows[pvrow_idx].back
+    eng.fast_mode_segment_index = None
+    pvarray = eng.run_fast_back_pvrow()
+    ts_side = pvarray.ts_pvrows[fast_mode_pvrow_index].back
     qinc = ts_side.get_param_weighted('qinc')
     # Check results
     np.testing.assert_allclose(qinc, 123.753462)
@@ -204,11 +203,13 @@ def test_run_fast_mode_back_shading(params):
     irradiance_model = HybridPerezOrdered()
     pvarray = OrderedPVArray.init_from_dict(
         params, param_names=irradiance_model.params)
-    fast_mode_pvrow_index = None  # 1
+    fast_mode_pvrow_index = 1
+    fast_mode_segment_index = 0
 
     # Create engine object
     eng = PVEngine(pvarray, irradiance_model=irradiance_model,
-                   fast_mode_pvrow_index=fast_mode_pvrow_index)
+                   fast_mode_pvrow_index=fast_mode_pvrow_index,
+                   fast_mode_segment_index=fast_mode_segment_index)
 
     # Irradiance inputs
     timestamps = dt.datetime(2019, 6, 11, 11)
@@ -224,20 +225,18 @@ def test_run_fast_mode_back_shading(params):
             params['surface_tilt'], params['surface_azimuth'],
             params['rho_ground'])
 
-    # Run fast mode
-    pvrow_idx = 1
-
     # By providing segment index
-    segment_idx = 0
-    pvarray = eng.run_fast_back_pvrow(pvrow_idx, segment_idx=segment_idx)
-    ts_seg = pvarray.ts_pvrows[pvrow_idx].back.list_segments[segment_idx]
+    pvarray = eng.run_fast_back_pvrow()
+    ts_seg = (pvarray.ts_pvrows[fast_mode_pvrow_index]
+              .back.list_segments[fast_mode_segment_index])
     qinc = ts_seg.get_param_weighted('qinc')
     # Check results
     np.testing.assert_allclose(qinc, expected_qinc)
 
     # Without providing segment index
-    pvarray = eng.run_fast_back_pvrow(pvrow_idx)
-    ts_side = pvarray.ts_pvrows[pvrow_idx].back
+    eng.fast_mode_segment_index = None
+    pvarray = eng.run_fast_back_pvrow()
+    ts_side = pvarray.ts_pvrows[fast_mode_pvrow_index].back
     qinc = ts_side.get_param_weighted('qinc')
     # Check results
     np.testing.assert_allclose(qinc, expected_qinc)

--- a/pvfactors/tests/test_engine.py
+++ b/pvfactors/tests/test_engine.py
@@ -175,8 +175,18 @@ def test_run_fast_mode(params):
 
     # Run fast mode
     pvrow_idx = 1
-    segment_idx = 0
-    qinc = eng.run_fast_back_pvrow(pvrow_idx, segment_idx=segment_idx)
 
+    # By providing segment index
+    segment_idx = 0
+    pvarray = eng.run_fast_back_pvrow(pvrow_idx, segment_idx=segment_idx)
+    ts_seg = pvarray.ts_pvrows[pvrow_idx].back.list_segments[segment_idx]
+    qinc = ts_seg.get_param_weighted('qinc')
+    # Check results
+    np.testing.assert_allclose(qinc, 123.753462)
+
+    # Without providing segment index
+    pvarray = eng.run_fast_back_pvrow(pvrow_idx)
+    ts_side = pvarray.ts_pvrows[pvrow_idx].back
+    qinc = ts_side.get_param_weighted('qinc')
     # Check results
     np.testing.assert_allclose(qinc, 123.753462)

--- a/pvfactors/tests/test_engine.py
+++ b/pvfactors/tests/test_engine.py
@@ -176,8 +176,7 @@ def test_run_fast_mode(params):
     # Run fast mode
     pvrow_idx = 1
     segment_idx = 0
-    eng.run_fast_back_pvrow(pvrow_idx, segment_idx=segment_idx)
-    # # Checks
-    # assert isinstance(pvarray, OrderedPVArray)
-    # np.testing.assert_almost_equal(
-    #     pvarray.pvrows[1].back.get_param_weighted('qinc'), 123.7087347744459)
+    qinc = eng.run_fast_back_pvrow(pvrow_idx, segment_idx=segment_idx)
+
+    # Check results
+    np.testing.assert_allclose(qinc, 123.753462)

--- a/pvfactors/tests/test_engine.py
+++ b/pvfactors/tests/test_engine.py
@@ -2,6 +2,7 @@ from pvfactors.engine import PVEngine
 from pvfactors.geometry import OrderedPVArray
 from pvfactors.irradiance import IsotropicOrdered, HybridPerezOrdered
 from pvfactors.irradiance.utils import breakup_df_inputs
+from pvfactors.report import example_fn_build_report_fast_mode
 import numpy as np
 import datetime as dt
 
@@ -176,18 +177,15 @@ def test_run_fast_mode(params):
     np.testing.assert_almost_equal(eng.irradiance.direct['front_pvrow'], DNI)
 
     # Run fast mode
-    pvarray = eng.run_fast_back_pvrow()
-    ts_seg = (pvarray.ts_pvrows[fast_mode_pvrow_index]
-              .back.list_segments[fast_mode_segment_index])
-    qinc = ts_seg.get_param_weighted('qinc')
+    qinc = eng.run_fast_back_pvrow(
+        fn_build_report=example_fn_build_report_fast_mode)
     # Check results
     np.testing.assert_allclose(qinc, 123.753462)
 
     # Without providing segment index
     eng.fast_mode_segment_index = None
-    pvarray = eng.run_fast_back_pvrow()
-    ts_side = pvarray.ts_pvrows[fast_mode_pvrow_index].back
-    qinc = ts_side.get_param_weighted('qinc')
+    qinc = eng.run_fast_back_pvrow(
+        fn_build_report=example_fn_build_report_fast_mode)
     # Check results
     np.testing.assert_allclose(qinc, 123.753462)
 
@@ -226,17 +224,14 @@ def test_run_fast_mode_back_shading(params):
             params['rho_ground'])
 
     # By providing segment index
-    pvarray = eng.run_fast_back_pvrow()
-    ts_seg = (pvarray.ts_pvrows[fast_mode_pvrow_index]
-              .back.list_segments[fast_mode_segment_index])
-    qinc = ts_seg.get_param_weighted('qinc')
+    qinc = eng.run_fast_back_pvrow(
+        fn_build_report=example_fn_build_report_fast_mode)
     # Check results
     np.testing.assert_allclose(qinc, expected_qinc)
 
     # Without providing segment index
     eng.fast_mode_segment_index = None
-    pvarray = eng.run_fast_back_pvrow()
-    ts_side = pvarray.ts_pvrows[fast_mode_pvrow_index].back
-    qinc = ts_side.get_param_weighted('qinc')
+    qinc = eng.run_fast_back_pvrow(
+        fn_build_report=example_fn_build_report_fast_mode)
     # Check results
     np.testing.assert_allclose(qinc, expected_qinc)

--- a/pvfactors/tests/test_engine.py
+++ b/pvfactors/tests/test_engine.py
@@ -176,7 +176,7 @@ def test_run_fast_mode(params):
     # Run fast mode
     pvrow_idx = 1
     segment_idx = 0
-    eng.run_fast_mode(pvrow_idx, segment_idx=segment_idx)
+    eng.run_fast_back_pvrow(pvrow_idx, segment_idx=segment_idx)
     # # Checks
     # assert isinstance(pvarray, OrderedPVArray)
     # np.testing.assert_almost_equal(

--- a/pvfactors/tests/test_geometry/test_timeseries.py
+++ b/pvfactors/tests/test_geometry/test_timeseries.py
@@ -159,20 +159,6 @@ def test_ts_ground_from_ts_pvrow():
     for surf in ground_0.all_surfaces:
         assert surf.param_names == param_names
 
-    is_ci = os.environ.get('CI', False)
-
-    if not is_ci:
-        import matplotlib.pyplot as plt
-
-        # Plot it at ts 0
-        f, ax = plt.subplots()
-        ts_pvrow.plot_at_idx(0, ax)
-        ts_ground.plot_at_idx(0, ax, merge_if_flag_overlap=True,
-                              with_cut_points=True)
-        ax.axis('equal')
-        ax.set_xlim(-3, 6)
-        plt.show()
-
 
 def test_ts_ground_overlap():
 
@@ -236,18 +222,6 @@ def test_ts_ground_to_geometry():
     assert pvground.list_segments[0].illum_collection.n_surfaces == 2
     assert pvground.list_segments[0].shaded_collection.n_surfaces == 2
     assert pvground.list_segments[0].shaded_collection.length == 5
-
-    is_ci = os.environ.get('CI', False)
-
-    if not is_ci:
-        import matplotlib.pyplot as plt
-
-        # Plot it at ts 0
-        f, ax = plt.subplots()
-        ts_ground.plot_at_idx(0, ax, merge_if_flag_overlap=True,
-                              with_cut_points=True)
-        ax.set_xlim(-1, 6)
-        plt.show()
 
 
 def test_shadows_coords_left_right_of_cut_point():

--- a/pvfactors/tests/test_irradiance/test_models.py
+++ b/pvfactors/tests/test_irradiance/test_models.py
@@ -509,7 +509,7 @@ def test_hybridperez_circ_shading():
     solar_2d_vector = [1.2, 1]  # <45 deg elevation so should have >50% shading
     idx_neighbor = 0
 
-    circ_shading_pct = irr_model.calculate_circumsolar_shading_pct(
+    circ_shading_pct = irr_model._calculate_circumsolar_shading_pct(
         surf, idx_neighbor, pvrows, solar_2d_vector)
 
     np.testing.assert_almost_equal(circ_shading_pct, 71.5969299216)
@@ -544,7 +544,7 @@ def test_hybridperez_horizon_shading_ts():
     centroid_coords = (pvarray.ts_pvrows[pvrow_idx].back.list_segments[0]
                        .coords.centroid)
     tilted_to_left = pvarray.rotation_vec > 0
-    horizon_pct_shading = model.calculate_horizon_shading_pct_ts(
+    horizon_pct_shading = model._calculate_horizon_shading_pct_ts(
         pvarray.ts_pvrows, centroid_coords, pvrow_idx, tilted_to_left,
         is_back_side=True)
 

--- a/pvfactors/tests/test_irradiance/test_models.py
+++ b/pvfactors/tests/test_irradiance/test_models.py
@@ -55,7 +55,7 @@ def test_isotropic_model_front(params_irr):
     # Create, fit, and transform pv array
     pvarray = OrderedPVArray.fit_from_dict_of_scalars(
         params_irr, param_names=IsotropicOrdered.params)
-    irr_model.transform_ts(pvarray)
+    irr_model.transform(pvarray)
     pvarray.transform(idx=0)
 
     # there should be some direct shading
@@ -148,7 +148,7 @@ def test_isotropic_model_back(params_irr):
     # Create, fit, and transform pv array
     pvarray = OrderedPVArray.fit_from_dict_of_scalars(
         params_irr, param_names=IsotropicOrdered.params)
-    irr_model.transform_ts(pvarray)
+    irr_model.transform(pvarray)
     pvarray.transform(idx=0)
 
     # there should be some direct shading
@@ -242,7 +242,7 @@ def test_hybridperez_ordered_front(params_irr):
     # Create, fit, and transform pv array
     pvarray = OrderedPVArray.fit_from_dict_of_scalars(
         params_irr, param_names=IsotropicOrdered.params)
-    irr_model.transform_ts(pvarray)
+    irr_model.transform(pvarray)
     pvarray.transform(idx=0)
 
     # there should be some direct shading
@@ -386,7 +386,7 @@ def test_hybridperez_ordered_back(params_irr):
     # Create, fit, and transform pv array
     pvarray = OrderedPVArray.fit_from_dict_of_scalars(
         params_irr, param_names=IsotropicOrdered.params)
-    irr_model.transform_ts(pvarray)
+    irr_model.transform(pvarray)
     pvarray.transform(idx=0)
 
     # there should be some direct shading
@@ -554,7 +554,7 @@ def test_hybridperez_horizon_shading_ts():
     np.testing.assert_allclose(expected_pct_shading, horizon_pct_shading)
 
 
-def test_hybridperez_transform_ts(df_inputs_clearsky_8760):
+def test_hybridperez_transform(df_inputs_clearsky_8760):
 
     n_points = 24
     df_inputs = df_inputs_clearsky_8760.iloc[:n_points, :]
@@ -580,7 +580,7 @@ def test_hybridperez_transform_ts(df_inputs_clearsky_8760):
               df_inputs.solar_zenith.values, df_inputs.solar_azimuth.values,
               df_inputs.surface_tilt.values, df_inputs.surface_azimuth.values,
               albedo)
-    model.transform_ts(pvarray)
+    model.transform(pvarray)
 
     # Check timeseries parameters
     expected_middle_back_horizon = np.array(

--- a/pvfactors/tests/test_viewfactors/test_calculator.py
+++ b/pvfactors/tests/test_viewfactors/test_calculator.py
@@ -101,8 +101,14 @@ def test_ts_view_factors():
     ts_ground = pvarray.ts_ground
     rotation_vec = pvarray.rotation_vec
     calculator = VFCalculator()
-    view_factors = calculator.get_vf_ts_pvrow_segment(
-        pvrow_idx, segment_idx, ts_pvrows, ts_ground, rotation_vec,
+    ts_segment = ts_pvrows[pvrow_idx].back.list_segments[segment_idx]
+    # Calculate view factors for segment
+    view_factors_segment = calculator.get_vf_ts_pvrow_element(
+        pvrow_idx, ts_segment, ts_pvrows, ts_ground, rotation_vec,
+        pvarray.width)
+    # Calculate view factors for segment's illum surface (should be identical)
+    view_factors_illum = calculator.get_vf_ts_pvrow_element(
+        pvrow_idx, ts_segment.illum, ts_pvrows, ts_ground, rotation_vec,
         pvarray.width)
 
     expected_vf_to_obstructed_shadows = np.array([
@@ -118,6 +124,12 @@ def test_ts_view_factors():
     expected_vf_to_pvrow_shaded = np.array([0., 0., 0., 0.068506, 0.])
     expected_vf_to_sky = np.array(
         [0.070879, 0.070879, 0.070879, 0.070879, -0.])
+    # Test that segment and segment's illum surface values are identical
+    for k, _ in view_factors_segment.items():
+        np.testing.assert_almost_equal(
+            view_factors_illum[k], view_factors_segment[k], decimal=6)
+    # Now test that values are always consistent
+    view_factors = view_factors_segment
     np.testing.assert_almost_equal(expected_vf_to_obstructed_shadows,
                                    view_factors['to_each_gnd_shadow'],
                                    decimal=6)

--- a/pvfactors/tests/test_viewfactors/test_calculator.py
+++ b/pvfactors/tests/test_viewfactors/test_calculator.py
@@ -2,6 +2,7 @@ from pvfactors.viewfactors.calculator import VFCalculator
 from pvfactors.geometry import OrderedPVArray
 from pvfactors.irradiance import HybridPerezOrdered
 from pvfactors.engine import PVEngine
+from pvfactors.tests.test_engine import _fast_mode_with_loop
 import datetime as dt
 from pvfactors.tests.test_viewfactors.test_data import \
     vf_matrix_left_cut, vf_left_cut_sum_axis_one_rounded
@@ -48,7 +49,9 @@ def test_vf_matrix_subset_calculation(params):
             params['surface_tilt'],
             params['surface_azimuth'],
             params['rho_ground'])
-    pvarray_fast = eng.run_timestep(0)
+    pvarray_fast = _fast_mode_with_loop(
+        eng.pvarray, eng.irradiance,
+        eng.vf_calculator, fast_mode_pvrow_index, 0)
     vf_mat_fast = pvarray_fast.vf_matrix
 
     # Run in full mode
@@ -64,7 +67,7 @@ def test_vf_matrix_subset_calculation(params):
             params['surface_tilt'],
             params['surface_azimuth'],
             params['rho_ground'])
-    pvarray_full = eng.run_timestep(0)
+    pvarray_full = eng.run_full_mode_timestep(0)
     vf_mat_full = pvarray_full.vf_matrix
 
     index_of_back_side_surface = 13

--- a/pvfactors/tests/test_viewfactors/test_calculator.py
+++ b/pvfactors/tests/test_viewfactors/test_calculator.py
@@ -73,7 +73,7 @@ def test_vf_matrix_subset_calculation(params):
 
 
 def test_ts_view_factors():
-
+    """Test calculation of timeseries view factors for center PV row"""
     # Create base params
     params = {
         'axis_azimuth': 0,

--- a/pvfactors/viewfactors/calculator.py
+++ b/pvfactors/viewfactors/calculator.py
@@ -460,8 +460,11 @@ class VFTsMethods(object):
         pvrow_element_highest_pt = pvrow_element.highest_point
         # Calculate view factors to left shadows
         if pvrow_idx == 0:
-            vf_to_left_shadow = np.zeros(n_steps)
+            # There is no obstruction on the left
+            vf_to_left_shadow = self._vf_surface_to_surface(
+                pvrow_element.coords, shadow_left, pvrow_element_length)
         else:
+            # There is potential obstruction on the left
             pt_obstr = ts_pvrows[pvrow_idx - 1].full_pvrow_coords.lowest_point
             is_shadow_left = True
             vf_to_left_shadow = self._vf_hottel_shadows(
@@ -471,8 +474,11 @@ class VFTsMethods(object):
 
         # Calculate view factors to right shadows
         if pvrow_idx == n_shadows - 1:
-            vf_to_right_shadow = np.zeros(n_steps)
+            # There is no obstruction on the right
+            vf_to_right_shadow = self._vf_surface_to_surface(
+                pvrow_element.coords, shadow_right, pvrow_element_length)
         else:
+            # There is potential obstruction on the right
             pt_obstr = ts_pvrows[pvrow_idx + 1].full_pvrow_coords.lowest_point
             is_shadow_left = False
             vf_to_right_shadow = self._vf_hottel_shadows(


### PR DESCRIPTION
* Update ``PVEngine`` so that it can run the complete timeseries fast mode simulations
* Remove the old fast mode method (archive it in ``test_engine.py``) and update engine API
* Update the run functions as well
* Fix: make sure the engine can pass GHI data to the irradiance models