### PR TITLE
Release v1.3.0

### DIFF
--- a/docs/sphinx/whatsnew.rst
+++ b/docs/sphinx/whatsnew.rst
@@ -6,6 +6,7 @@ What's New
 
 These are new features and improvements of note in each release.
 
+.. include:: whatsnew/v1.3.0.rst
 .. include:: whatsnew/v1.2.2.rst
 .. include:: whatsnew/v1.2.1.rst
 .. include:: whatsnew/v1.2.0.rst

--- a/docs/sphinx/whatsnew/v1.3.0.rst
+++ b/docs/sphinx/whatsnew/v1.3.0.rst
@@ -6,10 +6,8 @@ v1.3.0 (November 6, 2019)
 Enhancements
 ------------
 
-pvfactors is now only using timeseries geometries and vectorization for the view factor matrix calculation,
-even with the full reflection equilibrium mode.
-This resulted in an incredible speed boost, in which 8760 simulations now run in less than 2 seconds when using the full mode (it previously took a couple minutes).
-So there's not much reason anymore to use the "fast" mode, which is less accurate and not that faster anymore.
+pvfactors is now only using timeseries geometries and vectorization for the view factor matrix calculation, even with the full reflection equilibrium mode.
+This resulted in an incredible speed boost, in which 8760 simulations now run in less than 2 seconds when using the full mode (it previously took a couple minutes). So there's not much reason anymore to use the "fast" mode, which is less accurate and not that faster anymore.
 Lots of package clean up and documentation updates in addition to this.
 
 * Create timeseries ground elements (#80)

--- a/docs/sphinx/whatsnew/v1.3.0.rst
+++ b/docs/sphinx/whatsnew/v1.3.0.rst
@@ -1,0 +1,28 @@
+.. _whatsnew_1300:
+
+v1.3.0 (November 6, 2019)
+=========================
+
+Enhancements
+------------
+
+pvfactors is now only using timeseries geometries and vectorization for the view factor matrix calculation,
+even with the full reflection equilibrium mode.
+This resulted in an incredible speed boost, in which 8760 simulations now run in less than 2 seconds when using the full mode (it previously took a couple minutes).
+So there's not much reason anymore to use the "fast" mode, which is less accurate and not that faster anymore.
+Lots of package clean up and documentation updates in addition to this.
+
+* Create timeseries ground elements (#80)
+* Index all timeseries surfaces (#82)
+* Vectorize calculation of vf matrix (#83)
+* Implement vectorized full mode (#84)
+* Clean up package now that full mode is vectorized (#86)
+* Reorganize geometry sub-package (#87)
+* Add docs section on main concepts (#88)
+* Update docs tutorials (#89)
+
+
+Contributors
+------------
+
+* Marc Anoma (:ghuser:`anomam`)


### PR DESCRIPTION
Enhancements
------------

pvfactors is now only using timeseries geometries and vectorization for the view factor matrix calculation, even with the full reflection equilibrium mode.
This resulted in an incredible speed boost, in which 8760 simulations now run in less than 2 seconds when using the full mode (it previously took a couple minutes). So there's not much reason anymore to use the "fast" mode, which is less accurate and not that faster anymore.
Lots of package clean up and documentation updates in addition to this.

* Create timeseries ground elements (#80)
* Index all timeseries surfaces (#82)
* Vectorize calculation of vf matrix (#83)
* Implement vectorized full mode (#84)
* Clean up package now that full mode is vectorized (#86)
* Reorganize geometry sub-package (#87)
* Add docs section on main concepts (#88)
* Update docs tutorials (#89)
