### PR TITLE
Implement fAOI modifiers for irradiance models

### DIFF
--- a/pvfactors/config.py
+++ b/pvfactors/config.py
@@ -12,6 +12,8 @@ Y_GROUND = 0.
 
 # PV rows parameters
 X_ORIGIN_PVROWS = 0.
+DEFAULT_RHO_FRONT = 0.01
+DEFAULT_RHO_BACK = 0.03
 
 # Define colors used for plotting the 2D arrays
 COLOR_DIC = {

--- a/pvfactors/irradiance/base.py
+++ b/pvfactors/irradiance/base.py
@@ -9,10 +9,6 @@ class BaseModel(object):
     cats = None
     irradiance_comp = None
 
-    def __init__(self, *args, **kwargs):
-        """Not implemented"""
-        raise NotImplementedError
-
     def fit(self, *args, **kwargs):
         """Not implemented"""
         raise NotImplementedError
@@ -110,3 +106,31 @@ class BaseModel(object):
         for component in self.irradiance_comp:
             value += ts_surface.get_param(component)
         ts_surface.update_params({name_sky_term: value})
+
+    def initialize_rho(self, rho_scalar, rho_calculated, default_value):
+        """Initialize reflectivity value:
+        - if a scalar value is passed, use it
+        - otherwise try to use calculated value
+        - else use default value
+
+        Parameters
+        ----------
+        rho_scalar : float
+            Global average reflectivity value that is supposed to be used
+        rho_calculated : float
+            Reflectivity value calculated
+        default_value : float
+            Default value to use if everything fails
+
+        Returns
+        -------
+        rho_scalar : float
+            Global average reflectivity
+        """
+        if np.isscalar(rho_scalar):
+            rho_scalar = rho_scalar
+        elif np.isscalar(rho_calculated):
+            rho_scalar = rho_calculated
+        else:
+            rho_scalar = default_value
+        return rho_scalar

--- a/pvfactors/irradiance/base.py
+++ b/pvfactors/irradiance/base.py
@@ -91,6 +91,35 @@ class BaseModel(object):
 
         return irradiance_mat, rho_mat, invrho_mat, total_perez_mat
 
+    def get_summed_components(self, pvarray, absorbed=True):
+        """Get sum of irradiance components for irradiance model,
+        either absorbed or only incident.
+
+        Parameters
+        ----------
+        pvarray : PV array object
+            PV array with the irradiance and reflectivity values
+        absorbed : bool, optional
+            Flag to decide whether to use the absorbed components are not
+            (default = True)
+
+        Returns
+        -------
+        irradiance_mat : list
+            Matrix of summed up non-reflective irradiance values for all
+            timeseries surfaces. Dimension = [n_surfaces, n_timesteps]"""
+        # Initialize
+        list_components = (self.irradiance_comp_absorbed if absorbed
+                           else self.irradiance_comp)
+        # Build list
+        irradiance_mat = []
+        for ts_surface in pvarray.all_ts_surfaces:
+            value = np.zeros(pvarray.n_states, dtype=float)
+            for component in list_components:
+                value += ts_surface.get_param(component)
+            irradiance_mat.append(value)
+        return irradiance_mat
+
     def update_ts_surface_sky_term(self, ts_surface, name_sky_term='sky_term'):
         """Update the 'sky_term' parameter of a timeseries surface.
 

--- a/pvfactors/irradiance/models.py
+++ b/pvfactors/irradiance/models.py
@@ -443,6 +443,7 @@ class HybridPerezOrdered(BaseModel):
         self.total_perez = dict.fromkeys(self.cats)
         self.faoi_front = dict.fromkeys(self.cats)
         self.faoi_back = dict.fromkeys(self.cats)
+        self.faoi_ground = None
         self.horizon_band_angle = horizon_band_angle
         self.circumsolar_angle = circumsolar_angle
         self.circumsolar_model = circumsolar_model

--- a/pvfactors/irradiance/models.py
+++ b/pvfactors/irradiance/models.py
@@ -25,7 +25,8 @@ class IsotropicOrdered(BaseModel):
     irradiance_comp = ['direct']
 
     def __init__(self, rho_front=0.01, rho_back=0.03, module_transparency=0.,
-                 module_spacing_ratio=0.):
+                 module_spacing_ratio=0., faoi_fn_front=None,
+                 faoi_fn_back=None):
         """Initialize irradiance model values that will be saved later on.
 
         Parameters
@@ -44,17 +45,31 @@ class IsotropicOrdered(BaseModel):
             PV rows, and which determines how much direct light will reach the
             shaded ground through the PV rows
             (Default = 0., no spacing at all)
+        faoi_fn_front : function, optional
+            Function which takes a list (or numpy array) of incidence angles
+            measured from the surface horizontal
+            (with values from 0 to 180 deg) and returns the fAOI values for
+            the front side of PV rows (default=None)
+        faoi_fn_back : function, optional
+            Function which takes a list (or numpy array) of incidence angles
+            measured from the surface horizontal
+            (with values from 0 to 180 deg) and returns the fAOI values for
+            the back side of PV rows (default=None)
         """
         self.direct = dict.fromkeys(self.cats)
         self.total_perez = dict.fromkeys(self.cats)
-        self.isotropic_luminance = None
-        self.rho_front = rho_front
-        self.rho_back = rho_back
         self.module_transparency = module_transparency
         self.module_spacing_ratio = module_spacing_ratio
+        self.rho_front = rho_front
+        self.rho_back = rho_back
+        self.faoi_fn_front = faoi_fn_front
+        self.faoi_fn_back = faoi_fn_back
+
+        # The following will be updated at fitting time
         self.albedo = None
         self.GHI = None
         self.DHI = None
+        self.isotropic_luminance = None
 
     def fit(self, timestamps, DNI, DHI, solar_zenith, solar_azimuth,
             surface_tilt, surface_azimuth, albedo,

--- a/pvfactors/tests/conftest.py
+++ b/pvfactors/tests/conftest.py
@@ -190,3 +190,9 @@ def df_inputs_clearsky_8760():
     df = pd.read_csv(fp, index_col=0)
     df.index = pd.DatetimeIndex(df.index).tz_convert(tz)
     yield df
+
+
+@pytest.fixture(scope='function')
+def pvmodule_canadian():
+    """Example of pvlib PV module name to use in tests"""
+    yield 'Canadian_Solar_CS5P_220M___2009_'

--- a/pvfactors/tests/test_irradiance/test_models.py
+++ b/pvfactors/tests/test_irradiance/test_models.py
@@ -1,5 +1,6 @@
 import pytest
 from pvfactors.irradiance import IsotropicOrdered, HybridPerezOrdered
+from pvfactors.irradiance.base import BaseModel
 from pvfactors.geometry.pvarray import OrderedPVArray
 from pvfactors.geometry.base import PVSurface
 from pvfactors.geometry.pvrow import PVRow
@@ -862,3 +863,21 @@ def test_isotropic_ordered_transparency_spacing(params_irr):
                         .illum.list_ts_surfaces[0])
     np.testing.assert_allclose(surf_pvrow_illum.get_param('direct') * 0.19,
                                surf_pvrow_shaded.get_param('direct'))
+
+
+def test_initialize_rho():
+    """Make sure that rho is initialized correctly"""
+    model = BaseModel()
+    # rho values
+    rho_scalar = 0.50
+    rho_default = 0.01
+    rho_calculated = 0.10
+    # Should use scalar input
+    rho_out = model.initialize_rho(rho_scalar, rho_calculated, rho_default)
+    assert rho_out == rho_scalar
+    # Should use calculated
+    rho_out = model.initialize_rho(None, rho_calculated, rho_default)
+    np.testing.assert_allclose(rho_out, rho_calculated)
+    # Should use default
+    rho_out = model.initialize_rho(None, None, rho_default)
+    np.testing.assert_allclose(rho_out, rho_default)

--- a/pvfactors/tests/test_irradiance/test_models.py
+++ b/pvfactors/tests/test_irradiance/test_models.py
@@ -136,6 +136,11 @@ def test_isotropic_model_front(params_irr):
     # check that 2 dimensional
     assert np.shape(irradiance_mat) == (40, 1)
 
+    # check faoi modifiers
+    assert irr_model.faoi_back['direct'] == 0.97
+    assert irr_model.faoi_front['direct'] == 0.99
+    assert irr_model.faoi_ground == 0.8
+
 
 def test_isotropic_model_back(params_irr):
     """Direct shading on back surface"""
@@ -421,6 +426,12 @@ def test_hybridperez_ordered_front(params_irr):
 
     # check that 2 dimensional
     assert irradiance_mat.shape == (41, 1)
+
+    # check faoi modifiers
+    assert irr_model.faoi_back['circumsolar'] == 0.97
+    assert irr_model.faoi_back['horizon'] == 0.97
+    assert irr_model.faoi_front['direct'] == 0.99
+    assert irr_model.faoi_ground == 0.8
 
 
 def test_hybridperez_ordered_back(params_irr):

--- a/pvfactors/tests/test_irradiance/test_models.py
+++ b/pvfactors/tests/test_irradiance/test_models.py
@@ -449,7 +449,6 @@ def test_hybridperez_ordered_front(params_irr):
     np.testing.assert_allclose(np.array(irr_comp_absorbed)[12, 0],
                                (1. - params_irr['rho_ground']) *
                                np.array(irradiance_mat)[12, 0])
-    print(np.squeeze(irr_comp_absorbed))
 
 
 def test_hybridperez_ordered_back(params_irr):

--- a/pvfactors/tests/test_irradiance/test_models.py
+++ b/pvfactors/tests/test_irradiance/test_models.py
@@ -141,6 +141,14 @@ def test_isotropic_model_front(params_irr):
     assert irr_model.faoi_front['direct'] == 0.99
     assert irr_model.faoi_ground == 0.8
 
+    # get absorbed sum of sky components
+    irr_comp_absorbed = irr_model.get_summed_components(pvarray, absorbed=True)
+    assert np.shape(irr_comp_absorbed) == (40, 1)
+    # Check a ground surface value
+    np.testing.assert_allclose(np.array(irr_comp_absorbed)[12, 0],
+                               (1. - params_irr['rho_ground']) *
+                               np.array(irradiance_mat)[12, 0])
+
 
 def test_isotropic_model_back(params_irr):
     """Direct shading on back surface"""
@@ -394,7 +402,8 @@ def test_hybridperez_ordered_front(params_irr):
         100., 100., 33.33333333, 33.33333333,
         100., 100., 33.33333333, 33.33333333,
         100., 100., 33.33333333, 33.33333333]
-    np.testing.assert_array_almost_equal(np.squeeze(invrho_mat), expected_invrho_mat)
+    np.testing.assert_array_almost_equal(np.squeeze(invrho_mat),
+                                         expected_invrho_mat)
     np.testing.assert_almost_equal(
         pvarray.ts_pvrows[0].front.get_param_weighted('rho'),
         params_irr['rho_front_pvrow'])
@@ -432,6 +441,15 @@ def test_hybridperez_ordered_front(params_irr):
     assert irr_model.faoi_back['horizon'] == 0.97
     assert irr_model.faoi_front['direct'] == 0.99
     assert irr_model.faoi_ground == 0.8
+
+    # get absorbed sum of sky components
+    irr_comp_absorbed = irr_model.get_summed_components(pvarray, absorbed=True)
+    assert np.shape(irr_comp_absorbed) == (40, 1)
+    # Check a ground surface value
+    np.testing.assert_allclose(np.array(irr_comp_absorbed)[12, 0],
+                               (1. - params_irr['rho_ground']) *
+                               np.array(irradiance_mat)[12, 0])
+    print(np.squeeze(irr_comp_absorbed))
 
 
 def test_hybridperez_ordered_back(params_irr):

--- a/pvfactors/tests/test_viewfactors/test_aoi_methods.py
+++ b/pvfactors/tests/test_viewfactors/test_aoi_methods.py
@@ -316,3 +316,17 @@ def test_vf_aoi_pvrow_to_sky(params):
                            0., 0.]
     np.testing.assert_array_almost_equal(sky_column, expected_sky_column,
                                          decimal=7)
+
+
+def test_rho_from_faoi_fn(pvmodule_canadian):
+    """Check that can correctly calculate rho from faoi function"""
+    faoi_fn = faoi_fn_from_pvlib_sandia(pvmodule_canadian)
+    n_points = 300
+    # use same faoi fn for front and back
+    aoi_methods = AOIMethods(faoi_fn, faoi_fn, n_integral_sections=n_points)
+
+    # Should be identical for front and back
+    rho_out = aoi_methods.rho_from_faoi_fn(True)
+    np.testing.assert_allclose(rho_out, 0.02900688, atol=0, rtol=1e-6)
+    rho_out = aoi_methods.rho_from_faoi_fn(False)
+    np.testing.assert_allclose(rho_out, 0.02900688, atol=0, rtol=1e-6)

--- a/pvfactors/tests/test_viewfactors/test_aoi_methods.py
+++ b/pvfactors/tests/test_viewfactors/test_aoi_methods.py
@@ -33,14 +33,17 @@ def test_ts_aoi_methods(pvmodule_canadian):
     - vf_aoi values stay consistent"""
     n_timestamps = 6  # using 5 timestamps
     n_points = 6  # using only 6 sections for the integral from 0 to 180 deg
-    aoi_methods = AOIMethods(faoi_fn_from_pvlib_sandia(pvmodule_canadian),
-                             n_integral_sections=n_points)
+    faoi_fn = faoi_fn_from_pvlib_sandia(pvmodule_canadian)
+    # use same faoi fn for front and back
+    aoi_methods = AOIMethods(faoi_fn, faoi_fn, n_integral_sections=n_points)
     aoi_methods.fit(n_timestamps)
     # Check that function was passed correctly
-    assert callable(aoi_methods.faoi_fn)
+    assert callable(aoi_methods.faoi_fn_front)
+    assert callable(aoi_methods.faoi_fn_back)
     assert aoi_methods.aoi_angles_low.shape == (n_timestamps, n_points)
     assert aoi_methods.aoi_angles_high.shape == (n_timestamps, n_points)
-    assert aoi_methods.integrand_values.shape == (n_timestamps, n_points)
+    assert aoi_methods.integrand_front.shape == (n_timestamps, n_points)
+    assert aoi_methods.integrand_back.shape == (n_timestamps, n_points)
 
     # Create some dummy angle values
     low_angles = np.array([0., 2., 108., 72., 179., 0.])
@@ -70,8 +73,8 @@ def test_sanity_check(pvmodule_canadian):
     view factor values make sense"""
     n_timestamps = 3  # using 5 timestamps
     n_points = 300  # using only 6 sections for the integral from 0 to 180 deg
-    aoi_methods = AOIMethods(lambda aoi_angles: np.ones_like(aoi_angles),
-                             n_integral_sections=n_points)
+    def faoi_fn(aoi_angles): return np.ones_like(aoi_angles)
+    aoi_methods = AOIMethods(faoi_fn, faoi_fn, n_integral_sections=n_points)
     aoi_methods.fit(n_timestamps)
     # Create some dummy angle values
     low_angles = np.array([0., 90., 0.])
@@ -116,8 +119,8 @@ def test_vf_aoi_pvrow_gnd_benchmark_no_obstruction():
     # Create aoi methods
     n_timestamps = 1
     n_points = 300  # using only 6 sections for the integral from 0 to 180 deg
-    aoi_methods = AOIMethods(lambda aoi_angles: np.ones_like(aoi_angles),
-                             n_integral_sections=n_points)
+    def faoi_fn(aoi_angles): return np.ones_like(aoi_angles)
+    aoi_methods = AOIMethods(faoi_fn, faoi_fn, n_integral_sections=n_points)
     aoi_methods.fit(n_timestamps)
 
     # Get parameters
@@ -182,8 +185,8 @@ def test_vf_aoi_pvrow_gnd_benchmark_with_obstruction():
     # Create aoi methods
     n_timestamps = 1
     n_points = 300  # using only 6 sections for the integral from 0 to 180 deg
-    aoi_methods = AOIMethods(lambda aoi_angles: np.ones_like(aoi_angles),
-                             n_integral_sections=n_points)
+    def faoi_fn(aoi_angles): return np.ones_like(aoi_angles)
+    aoi_methods = AOIMethods(faoi_fn, faoi_fn, n_integral_sections=n_points)
     aoi_methods.fit(n_timestamps)
 
     # Get parameters
@@ -281,8 +284,8 @@ def test_vf_aoi_pvrow_to_sky(params):
     # Create aoi methods
     n_timestamps = 1
     n_points = 300  # using only 6 sections for the integral from 0 to 180 deg
-    aoi_methods = AOIMethods(lambda aoi_angles: np.ones_like(aoi_angles),
-                             n_integral_sections=n_points)
+    def faoi_fn(aoi_angles): return np.ones_like(aoi_angles)
+    aoi_methods = AOIMethods(faoi_fn, faoi_fn, n_integral_sections=n_points)
     aoi_methods.fit(n_timestamps)
 
     # Create pv array

--- a/pvfactors/tests/test_viewfactors/test_aoi_methods.py
+++ b/pvfactors/tests/test_viewfactors/test_aoi_methods.py
@@ -4,12 +4,6 @@ from pvfactors.geometry.timeseries import TsPointCoords
 from pvfactors.geometry.pvarray import OrderedPVArray
 from pvfactors.viewfactors.vfmethods import VFTsMethods
 import numpy as np
-import pytest
-
-
-@pytest.fixture(scope='function')
-def pvmodule_canadian():
-    yield 'Canadian_Solar_CS5P_220M___2009_'
 
 
 def test_faoi_fn_from_pvlib():

--- a/pvfactors/tests/test_viewfactors/test_calculator.py
+++ b/pvfactors/tests/test_viewfactors/test_calculator.py
@@ -45,9 +45,9 @@ def test_vfcalculator_aoi_methods(params):
     n_integration_sections = 10000
 
     # Create vf calculator
+    def faoi_fn(aoi_angles): return np.ones_like(aoi_angles)
     vfcalculator = VFCalculator(
-        faoi_fn=lambda aoi_angles: np.ones_like(aoi_angles),
-        n_aoi_integral_sections=n_integration_sections)
+        faoi_fn, faoi_fn, n_aoi_integral_sections=n_integration_sections)
     vfcalculator.fit(n_timestamps)
     vf_aoi_matrix = vfcalculator.build_ts_vf_aoi_matrix(pvarray)
 

--- a/pvfactors/viewfactors/aoimethods.py
+++ b/pvfactors/viewfactors/aoimethods.py
@@ -3,6 +3,7 @@
 from pvfactors.config import DISTANCE_TOLERANCE
 from pvfactors.geometry.timeseries import (
     TsPointCoords, TsSurface, TsLineCoords)
+from pvfactors import PVFactorsError
 import pvlib
 from pvlib.tools import cosd
 import numpy as np
@@ -32,6 +33,12 @@ class AOIMethods:
             Number of integral divisions of the 0 to 180 deg interval
             to use for the fAOI loss integral (default = 300)
         """
+        # Check that faoi fn where passed
+        faoi_fns_ok = callable(faoi_fn_front) and callable(faoi_fn_back)
+        if not faoi_fns_ok:
+            raise PVFactorsError("The faoi_fn passed to the AOI methods are "
+                                 "not callable. Please check the fAOI "
+                                 "functions again")
         self.faoi_fn_front = faoi_fn_front
         self.faoi_fn_back = faoi_fn_back
         self.n_integral_sections = n_integral_sections

--- a/pvfactors/viewfactors/calculator.py
+++ b/pvfactors/viewfactors/calculator.py
@@ -12,24 +12,31 @@ class VFCalculator(object):
     rely on both :py:class:`~pvfactors.viewfactors.vfmethods.VFTsMethods`
     and :py:class:`~pvfactors.viewfactors.aoimethods.AOIMethods`"""
 
-    def __init__(self, faoi_fn=None, n_aoi_integral_sections=300):
+    def __init__(self, faoi_fn_front=None, faoi_fn_back=None,
+                 n_aoi_integral_sections=300):
         """Initialize the view factor calculator with the calculation methods
         that will be used.
 
         Parameters
         ----------
-        faoi_fn : function, optional
+        faoi_fn_front : function
             Function which takes a list (or numpy array) of incidence angles
             measured from the surface horizontal
-            (with values from 0 to 180 deg) and returns the fAOI values
-            (Default = None)
+            (with values from 0 to 180 deg) and returns the fAOI values for
+            the front side of PV rows
+        faoi_fn_back : function
+            Function which takes a list (or numpy array) of incidence angles
+            measured from the surface horizontal
+            (with values from 0 to 180 deg) and returns the fAOI values for
+            the back side of PV rows
         n_integral_sections : int, optional
             Number of integral divisions of the 0 to 180 deg interval
             to use for the fAOI loss integral (default = 300)
         """
         self.vf_ts_methods = VFTsMethods()
         self.vf_aoi_methods = AOIMethods(
-            faoi_fn, n_integral_sections=n_aoi_integral_sections)
+            faoi_fn_front, faoi_fn_back,
+            n_integral_sections=n_aoi_integral_sections)
         # Saved matrices
         self.vf_matrix = None
         self.vf_aoi_matrix = None

--- a/pvfactors/viewfactors/calculator.py
+++ b/pvfactors/viewfactors/calculator.py
@@ -15,7 +15,8 @@ class VFCalculator(object):
     def __init__(self, faoi_fn_front=None, faoi_fn_back=None,
                  n_aoi_integral_sections=300):
         """Initialize the view factor calculator with the calculation methods
-        that will be used.
+        that will be used. The AOI methods will not be instantiated if an
+        fAOI function is missing.
 
         Parameters
         ----------

--- a/pvfactors/viewfactors/calculator.py
+++ b/pvfactors/viewfactors/calculator.py
@@ -19,24 +19,28 @@ class VFCalculator(object):
 
         Parameters
         ----------
-        faoi_fn_front : function
+        faoi_fn_front : function, optional
             Function which takes a list (or numpy array) of incidence angles
             measured from the surface horizontal
             (with values from 0 to 180 deg) and returns the fAOI values for
-            the front side of PV rows
-        faoi_fn_back : function
+            the front side of PV rows (default = None)
+        faoi_fn_back : function, optional
             Function which takes a list (or numpy array) of incidence angles
             measured from the surface horizontal
             (with values from 0 to 180 deg) and returns the fAOI values for
-            the back side of PV rows
+            the back side of PV rows (default = None)
         n_integral_sections : int, optional
             Number of integral divisions of the 0 to 180 deg interval
             to use for the fAOI loss integral (default = 300)
         """
         self.vf_ts_methods = VFTsMethods()
-        self.vf_aoi_methods = AOIMethods(
-            faoi_fn_front, faoi_fn_back,
-            n_integral_sections=n_aoi_integral_sections)
+        # Do not instantiate AOIMethods if missing faoi function
+        if (faoi_fn_front is None) or (faoi_fn_back is None):
+            self.vf_aoi_methods = None
+        else:
+            self.vf_aoi_methods = AOIMethods(
+                faoi_fn_front, faoi_fn_back,
+                n_integral_sections=n_aoi_integral_sections)
         # Saved matrices
         self.vf_matrix = None
         self.vf_aoi_matrix = None
@@ -49,7 +53,8 @@ class VFCalculator(object):
         n_timestamps : int
             Number of simulation timestamps
         """
-        self.vf_aoi_methods.fit(n_timestamps)
+        if self.vf_aoi_methods is not None:
+            self.vf_aoi_methods.fit(n_timestamps)
 
     def build_ts_vf_matrix(self, pvarray):
         """Calculate timeseries view factor matrix for the given


### PR DESCRIPTION
The irradiance components calculated in the irradiance models need to be derated by the reflection losses in order to compute what is actually absorbed by the surfaces.
Implement methods to account for the AOI losses specific to each irradiance model component, and which are possibly function of the AOI.