### PR TITLE
Include fAOI losses from irradiance models in tests

### DIFF
--- a/pvfactors/irradiance/models.py
+++ b/pvfactors/irradiance/models.py
@@ -46,16 +46,18 @@ class IsotropicOrdered(BaseModel):
             PV rows, and which determines how much direct light will reach the
             shaded ground through the PV rows
             (Default = 0., no spacing at all)
-        faoi_fn_front : function, optional
-            Function which takes a list (or numpy array) of incidence angles
+        faoi_fn_front : function or object, optional
+            Function (or object containing ``faoi`` method)
+            which takes a list (or numpy array) of incidence angles
             measured from the surface horizontal
             (with values from 0 to 180 deg) and returns the fAOI values for
-            the front side of PV rows (default=None)
-        faoi_fn_back : function, optional
-            Function which takes a list (or numpy array) of incidence angles
+            the front side of PV rows (default = None)
+        faoi_fn_back : function or object, optional
+            Function (or object containing ``faoi`` method)
+            which takes a list (or numpy array) of incidence angles
             measured from the surface horizontal
             (with values from 0 to 180 deg) and returns the fAOI values for
-            the back side of PV rows (default=None)
+            the back side of PV rows (default = None)
         """
         self.direct = dict.fromkeys(self.cats)
         self.total_perez = dict.fromkeys(self.cats)
@@ -66,9 +68,13 @@ class IsotropicOrdered(BaseModel):
         self.module_spacing_ratio = module_spacing_ratio
         self.rho_front = rho_front
         self.rho_back = rho_back
+        # Treatment of faoi functions
+        faoi_fn_front = (faoi_fn_front.faoi if hasattr(faoi_fn_front, 'faoi')
+                         else faoi_fn_front)
+        faoi_fn_back = (faoi_fn_back.faoi if hasattr(faoi_fn_back, 'faoi')
+                        else faoi_fn_back)
         self.faoi_fn_front = faoi_fn_front
         self.faoi_fn_back = faoi_fn_back
-
         # The following will be updated at fitting time
         self.albedo = None
         self.GHI = None

--- a/pvfactors/tests/test_engine.py
+++ b/pvfactors/tests/test_engine.py
@@ -574,7 +574,7 @@ def test_create_engine_with_rho_init(params, pvmodule_canadian):
     np.testing.assert_allclose(engine.irradiance.rho_back, 0.02900688)
 
 
-def test_create_engine_with_rho_init(params, pvmodule_canadian):
+def test_engine_w_faoi_fn_in_irradiance_vfcalcs(params, pvmodule_canadian):
     """Run PV engine calcs with faoi functions for AOI losses"""
 
     # Irradiance inputs
@@ -582,10 +582,14 @@ def test_create_engine_with_rho_init(params, pvmodule_canadian):
     DNI = 1000.
     DHI = 100.
 
-    irradiance_model = HybridPerezOrdered()
     pvarray = OrderedPVArray.init_from_dict(params)
+    # create faoi function
     faoi_fn = faoi_fn_from_pvlib_sandia(pvmodule_canadian)
+    # create vf_calculator with faoi function
     vfcalculator = VFCalculator(faoi_fn_front=faoi_fn, faoi_fn_back=faoi_fn)
+    # create irradiance model with faoi function
+    irradiance_model = HybridPerezOrdered(faoi_fn_front=faoi_fn,
+                                          faoi_fn_back=faoi_fn)
     eng = PVEngine(pvarray, irradiance_model=irradiance_model,
                    vf_calculator=vfcalculator)
 
@@ -616,7 +620,7 @@ def test_create_engine_with_rho_init(params, pvmodule_canadian):
     # Check absorbed irradiance: calculated using faoi functions
     np.testing.assert_almost_equal(
         pvarray.ts_pvrows[2].front.get_param_weighted('qabs'),
-        [1099.1251094])
+        [1109.1180884])
     np.testing.assert_almost_equal(
         pvarray.ts_pvrows[1].back.get_param_weighted('qabs'),
-        [114.4690984])
+        [114.2143503])

--- a/pvfactors/tests/test_run.py
+++ b/pvfactors/tests/test_run.py
@@ -228,7 +228,8 @@ def test_run_timeseries_faoi_fn(params_serial, pvmodule_canadian,
     surface_tilt = df_inputs.surface_tilt.values
     surface_azimuth = df_inputs.surface_azimuth.values
 
-    expected_qinc = 542.018551
+    expected_qinc_back = 542.018551
+    expected_qinc_front = 5452.858863
 
     # --- Test without passing vf parameters
     # report function with test in it
@@ -243,7 +244,9 @@ def test_run_timeseries_faoi_fn(params_serial, pvmodule_canadian,
             vf_aoi_matrix[list_back_pvrow_idx, :, 12].sum(axis=1),
             [0.99, 0., 0.97, 0.])
 
-        return {'qinc_back': pvrow.back.get_param_weighted('qinc'),
+        return {'qinc_front': pvrow.front.get_param_weighted('qinc'),
+                'qabs_front': pvrow.front.get_param_weighted('qabs'),
+                'qinc_back': pvrow.back.get_param_weighted('qinc'),
                 'qabs_back': pvrow.back.get_param_weighted('qabs')}
 
     # create calculator
@@ -253,8 +256,12 @@ def test_run_timeseries_faoi_fn(params_serial, pvmodule_canadian,
         surface_azimuth, params_serial['rho_ground'],
         vf_calculator_params=None)
 
-    np.testing.assert_allclose(np.nansum(report['qinc_back']), expected_qinc)
+    np.testing.assert_allclose(np.nansum(report['qinc_back']),
+                               expected_qinc_back)
     np.testing.assert_allclose(np.nansum(report['qabs_back']), 525.757995)
+    np.testing.assert_allclose(np.nansum(report['qinc_front']),
+                               expected_qinc_front)
+    np.testing.assert_allclose(np.nansum(report['qabs_front']), 5398.330275)
 
     # --- Test when passing vf parameters
     # Prepare vf calc params
@@ -277,7 +284,9 @@ def test_run_timeseries_faoi_fn(params_serial, pvmodule_canadian,
             vf_aoi_matrix[list_back_pvrow_idx, :, 12].sum(axis=1),
             [0.97102, 0., 0.971548, 0.], atol=0, rtol=1e-6)
 
-        return {'qinc_back': pvrow.back.get_param_weighted('qinc'),
+        return {'qinc_front': pvrow.front.get_param_weighted('qinc'),
+                'qabs_front': pvrow.front.get_param_weighted('qabs'),
+                'qinc_back': pvrow.back.get_param_weighted('qinc'),
                 'qabs_back': pvrow.back.get_param_weighted('qabs')}
     # create calculator
     report = run_timeseries_engine(
@@ -286,8 +295,12 @@ def test_run_timeseries_faoi_fn(params_serial, pvmodule_canadian,
         surface_azimuth, params_serial['rho_ground'],
         vf_calculator_params=vf_calc_params)
 
-    np.testing.assert_allclose(np.nansum(report['qinc_back']), expected_qinc)
+    np.testing.assert_allclose(np.nansum(report['qinc_back']),
+                               expected_qinc_back)
     np.testing.assert_allclose(np.nansum(report['qabs_back']), 522.299276)
+    np.testing.assert_allclose(np.nansum(report['qinc_front']),
+                               expected_qinc_front)
+    np.testing.assert_allclose(np.nansum(report['qabs_front']), 5389.644557)
 
 
 def test_run_parallel_faoi_fn(params_serial, df_inputs_clearsky_8760):
@@ -303,7 +316,9 @@ def test_run_parallel_faoi_fn(params_serial, df_inputs_clearsky_8760):
     surface_tilt = df_inputs.surface_tilt.values
     surface_azimuth = df_inputs.surface_azimuth.values
 
-    expected_qinc = 542.018551
+    expected_qinc_back = 542.018551
+    expected_qinc_front = 5452.858863
+
     # create calculator
     report = run_parallel_engine(
         TestFAOIReportBuilder, params_serial,
@@ -311,8 +326,12 @@ def test_run_parallel_faoi_fn(params_serial, df_inputs_clearsky_8760):
         surface_azimuth, params_serial['rho_ground'],
         vf_calculator_params=None)
 
-    np.testing.assert_allclose(np.nansum(report['qinc_back']), expected_qinc)
+    np.testing.assert_allclose(np.nansum(report['qinc_back']),
+                               expected_qinc_back)
     np.testing.assert_allclose(np.nansum(report['qabs_back']), 525.757995)
+    np.testing.assert_allclose(np.nansum(report['qinc_front']),
+                               expected_qinc_front)
+    np.testing.assert_allclose(np.nansum(report['qabs_front']), 5398.330275)
 
     # --- Test when passing vf parameters
     # the following is a very high number to get agreement in
@@ -329,18 +348,23 @@ def test_run_parallel_faoi_fn(params_serial, df_inputs_clearsky_8760):
         surface_azimuth, params_serial['rho_ground'],
         vf_calculator_params=vf_calc_params)
 
-    np.testing.assert_allclose(np.nansum(report['qinc_back']), expected_qinc)
+    np.testing.assert_allclose(np.nansum(report['qinc_back']),
+                               expected_qinc_back)
     np.testing.assert_allclose(np.nansum(report['qabs_back']), 522.299276)
+    np.testing.assert_allclose(np.nansum(report['qinc_front']),
+                               expected_qinc_front)
+    np.testing.assert_allclose(np.nansum(report['qabs_front']), 5389.644557)
 
 
 class TestFAOIReportBuilder(object):
 
     @staticmethod
     def build(pvarray):
-        return {'qinc_back': pvarray.ts_pvrows[0].back
-                .get_param_weighted('qinc').tolist(),
-                'qabs_back': pvarray.ts_pvrows[0].back
-                .get_param_weighted('qabs').tolist()}
+        pvrow = pvarray.ts_pvrows[0]
+        return {'qinc_front': pvrow.front.get_param_weighted('qinc').tolist(),
+                'qabs_front': pvrow.front.get_param_weighted('qabs').tolist(),
+                'qinc_back': pvrow.back.get_param_weighted('qinc').tolist(),
+                'qabs_back': pvrow.back.get_param_weighted('qabs').tolist()}
 
     @staticmethod
     def merge(reports):

--- a/pvfactors/tests/test_run.py
+++ b/pvfactors/tests/test_run.py
@@ -1,7 +1,6 @@
 from pvfactors.run import run_timeseries_engine, run_parallel_engine
 from pvfactors.report import ExampleReportBuilder
 from pvfactors.viewfactors.aoimethods import faoi_fn_from_pvlib_sandia
-from pvfactors.viewfactors.calculator import VFCalculator
 import numpy as np
 import mock
 

--- a/pvfactors/tests/test_run.py
+++ b/pvfactors/tests/test_run.py
@@ -254,7 +254,7 @@ def test_run_timeseries_faoi_fn(params_serial, pvmodule_canadian,
         report_fn_with_tests_no_faoi, params_serial,
         timestamps, dni, dhi, solar_zenith, solar_azimuth, surface_tilt,
         surface_azimuth, params_serial['rho_ground'],
-        vf_calculator_params=None)
+        vf_calculator_params=None, irradiance_model_params=None)
 
     np.testing.assert_allclose(np.nansum(report['qinc_back']),
                                expected_qinc_back)
@@ -272,6 +272,8 @@ def test_run_timeseries_faoi_fn(params_serial, pvmodule_canadian,
     vf_calc_params = {'faoi_fn_front': faoi_fn,
                       'faoi_fn_back': faoi_fn,
                       'n_aoi_integral_sections': n_sections}
+    irr_params = {'faoi_fn_front': faoi_fn,
+                  'faoi_fn_back': faoi_fn}
 
     def report_fn_with_tests_w_faoi(pvarray):
         vf_aoi_matrix = pvarray.ts_vf_aoi_matrix
@@ -293,14 +295,15 @@ def test_run_timeseries_faoi_fn(params_serial, pvmodule_canadian,
         report_fn_with_tests_w_faoi, params_serial,
         timestamps, dni, dhi, solar_zenith, solar_azimuth, surface_tilt,
         surface_azimuth, params_serial['rho_ground'],
-        vf_calculator_params=vf_calc_params)
+        vf_calculator_params=vf_calc_params,
+        irradiance_model_params=irr_params)
 
     np.testing.assert_allclose(np.nansum(report['qinc_back']),
                                expected_qinc_back)
-    np.testing.assert_allclose(np.nansum(report['qabs_back']), 522.299276)
+    np.testing.assert_allclose(np.nansum(report['qabs_back']), 520.892016)
     np.testing.assert_allclose(np.nansum(report['qinc_front']),
                                expected_qinc_front)
-    np.testing.assert_allclose(np.nansum(report['qabs_front']), 5389.644557)
+    np.testing.assert_allclose(np.nansum(report['qabs_front']), 5347.050682)
 
 
 def test_run_parallel_faoi_fn(params_serial, df_inputs_clearsky_8760):
@@ -324,7 +327,8 @@ def test_run_parallel_faoi_fn(params_serial, df_inputs_clearsky_8760):
         TestFAOIReportBuilder, params_serial,
         timestamps, dni, dhi, solar_zenith, solar_azimuth, surface_tilt,
         surface_azimuth, params_serial['rho_ground'],
-        vf_calculator_params=None)
+        vf_calculator_params=None,
+        irradiance_model_params=None)
 
     np.testing.assert_allclose(np.nansum(report['qinc_back']),
                                expected_qinc_back)
@@ -340,20 +344,23 @@ def test_run_parallel_faoi_fn(params_serial, df_inputs_clearsky_8760):
     vf_calc_params = {'faoi_fn_front': FaoiClass,
                       'faoi_fn_back': FaoiClass,
                       'n_aoi_integral_sections': n_sections}
+    irr_params = {'faoi_fn_front': FaoiClass,
+                  'faoi_fn_back': FaoiClass}
 
     # create calculator
     report = run_parallel_engine(
         TestFAOIReportBuilder, params_serial,
         timestamps, dni, dhi, solar_zenith, solar_azimuth, surface_tilt,
         surface_azimuth, params_serial['rho_ground'],
-        vf_calculator_params=vf_calc_params)
+        vf_calculator_params=vf_calc_params,
+        irradiance_model_params=irr_params)
 
     np.testing.assert_allclose(np.nansum(report['qinc_back']),
                                expected_qinc_back)
-    np.testing.assert_allclose(np.nansum(report['qabs_back']), 522.299276)
+    np.testing.assert_allclose(np.nansum(report['qabs_back']), 520.892016)
     np.testing.assert_allclose(np.nansum(report['qinc_front']),
                                expected_qinc_front)
-    np.testing.assert_allclose(np.nansum(report['qabs_front']), 5389.644557)
+    np.testing.assert_allclose(np.nansum(report['qabs_front']), 5347.050682)
 
 
 class TestFAOIReportBuilder(object):


### PR DESCRIPTION
- it is important to also test the fAOI losses used in the irradiance models, because they are applied to terms with high magnitude (like DNI for instance)
- make sure tests pass for parallel and non-parallel modes as well