### PR TITLE
PVEngine needs to use timeseries albedo values

### DIFF
--- a/pvfactors/tests/test_viewfactors/test_calculator.py
+++ b/pvfactors/tests/test_viewfactors/test_calculator.py
@@ -86,9 +86,9 @@ def test_vfcalculator_no_aoi_functions(params):
     assert np.sum(vfcalculator.vf_matrix) > 0
     # Compute reflectivity
     rho_mat = np.tile([0.03] * (pvarray.n_ts_surfaces + 1),
-                      (pvarray.n_ts_surfaces + 1, 1)).T
+                      (1, pvarray.n_ts_surfaces + 1, 1)).T
     assert rho_mat.shape == (pvarray.n_ts_surfaces + 1,
-                             pvarray.n_ts_surfaces + 1)
+                             pvarray.n_ts_surfaces + 1, 1)
     vf_aoi_matrix = vfcalculator.build_ts_vf_aoi_matrix(pvarray, rho_mat)
 
     # Check that correct size

--- a/pvfactors/viewfactors/calculator.py
+++ b/pvfactors/viewfactors/calculator.py
@@ -136,7 +136,8 @@ class VFCalculator(object):
             PV array whose timeseries view factor AOI matrix to calculate
         rho_mat : np.ndarray
             2D matrix of reflectivity values for all the surfaces in the
-            PV array + sky. Shape = [n_ts_surfaces + 1, n_ts_surfaces + 1]
+            PV array + sky.
+            Shape = [n_ts_surfaces + 1, n_ts_surfaces + 1, n_timestamps]
 
         Returns
         -------
@@ -161,9 +162,7 @@ class VFCalculator(object):
         if self.vf_aoi_methods is None:
             # The reflection losses will be considered all diffuse.
             faoi_diffuse = 1. - rho_mat
-            # use broadcasting
-            vf_aoi_matrix = faoi_diffuse * np.moveaxis(vf_aoi_matrix, -1, 0)
-            vf_aoi_matrix = np.moveaxis(vf_aoi_matrix, 0, -1)
+            vf_aoi_matrix = faoi_diffuse * vf_aoi_matrix
         else:
             # Calculate vf_aoi between pvrow and ground surfaces
             self.vf_aoi_methods.vf_aoi_pvrow_to_gnd(ts_pvrows, ts_ground,


### PR DESCRIPTION
Problem
--------
With the vectorization of all the calculations in the PVEngine, a shortcut was taken with the reflectivity matrix, and instead of using all of the reflectivity values passed to the surfaces, only the values at timestep = 0 were used.

Fix
---
Build the full 3D reflectivity matrices instead of broadcast with 2D matrix at timestep = 0