### PR TITLE
Release v1.4.1

### DIFF
--- a/docs/sphinx/whatsnew.rst
+++ b/docs/sphinx/whatsnew.rst
@@ -6,6 +6,7 @@ What's New
 
 These are new features and improvements of note in each release.
 
+.. include:: whatsnew/v1.4.1.rst
 .. include:: whatsnew/v1.4.0.rst
 .. include:: whatsnew/v1.3.0.rst
 .. include:: whatsnew/v1.2.2.rst

--- a/docs/sphinx/whatsnew/v1.4.1.rst
+++ b/docs/sphinx/whatsnew/v1.4.1.rst
@@ -1,0 +1,16 @@
+.. _whatsnew_141:
+
+v1.4.1 (November 29, 2019)
+==========================
+
+Fix
+---
+
+The vectorization of the calculations (from v1.3.0) in the PVEngine had removed the ability to account for timeseries albedo values (it was only using the first albedo value). This fix repairs that issue by building the full 3D matrices for the reflectivity values (and the inverse reflectivity values as well).
+
+* PVEngine needs to use timeseries albedo values (#98)
+
+Contributors
+------------
+
+* Marc Anoma (:ghuser:`anomam`)


### PR DESCRIPTION
Fix
---

The vectorization of the calculations (from v1.3.0) in the PVEngine had removed the ability to account for timeseries albedo values (it was only using the first albedo value). This fix repairs that issue by building the full 3D matrices for the reflectivity values (and the inverse reflectivity values as well).

* PVEngine needs to use timeseries albedo values (#98)