### PR TITLE
Add import check for shapely/geos

### DIFF
--- a/docs/sphinx/installation/index.rst
+++ b/docs/sphinx/installation/index.rst
@@ -23,9 +23,9 @@ try installing conda from conda-forge with:
 
    $ conda install -c conda-forge shapely
 
-Windows users may also be able to resolve the issue by installing wheels from `Cristoph Gohlke`_.
+Windows users may also be able to resolve the issue by installing wheels from `Christoph Gohlke`_.
 
-.. _Cristoph Gohlke: https://www.lfd.uci.edu/~gohlke/pythonlibs/#shapely
+.. _Christoph Gohlke: https://www.lfd.uci.edu/~gohlke/pythonlibs/#shapely
 
 
 pvlib implementation

--- a/docs/sphinx/installation/index.rst
+++ b/docs/sphinx/installation/index.rst
@@ -15,6 +15,17 @@ The easiest way to install ``pvfactors`` is using pip_:
 
    $ pip install pvfactors
 
+However, installing ``shapely`` from PyPI may not install all the necessary binary dependencies.
+If you run into an error like ``OSError: [WinError 126] The specified module could not be found``,
+try installing conda from conda-forge with:
+
+.. code-block:: shell
+
+   $ conda install -c conda-forge shapely
+
+Windows users may also be able to resolve the issue by installing wheels from `Cristoph Gohlke`_.
+
+.. _Cristoph Gohlke: https://www.lfd.uci.edu/~gohlke/pythonlibs/#shapely
 
 
 pvlib implementation

--- a/pvfactors/__init__.py
+++ b/pvfactors/__init__.py
@@ -4,6 +4,22 @@ from pvfactors.version import __version__
 import logging
 logging.basicConfig()
 
+try:
+    from shapely.geos import lgeos
+except OSError as err:
+    # https://github.com/SunPower/pvfactors/issues/109
+    msg = (
+        "pvfactors encountered an error when importing the shapely package. "
+        "This often happens when a binary dependency is missing because "
+        "shapely was installed from PyPI using pip. Try reinstalling shapely "
+        "from another source like conda-forge with "
+        "`conda install -c conda-forge shapely`, or alternatively from "
+        "Cristoph Gohlke's website if you're on Windows: "
+        "https://www.lfd.uci.edu/~gohlke/pythonlibs/#shapely"
+    )
+    err.strerror += "; " + msg
+    raise err
+
 
 class PVFactorsError(Exception):
     pass

--- a/pvfactors/__init__.py
+++ b/pvfactors/__init__.py
@@ -14,7 +14,7 @@ except OSError as err:
         "shapely was installed from PyPI using pip. Try reinstalling shapely "
         "from another source like conda-forge with "
         "`conda install -c conda-forge shapely`, or alternatively from "
-        "Cristoph Gohlke's website if you're on Windows: "
+        "Christoph Gohlke's website if you're on Windows: "
         "https://www.lfd.uci.edu/~gohlke/pythonlibs/#shapely"
     )
     err.strerror += "; " + msg


### PR DESCRIPTION
Closes #109

One consequence of doing this check in `__init__.py` is that it makes it impossible to use pvfactors at all if `shapely.geos.lgeos` can't be imported.  I've not actually used pvfactors before so maybe this is a silly question, but is there any pvfactors functionality that doesn't require shapely?  If so, maybe this warrants a more targeted change.

I ran into difficulties testing py2.7, but here's the output I get with py3.7:
```
(pvfactors-dev) C:\Users\KANDERSO\projects\pvfactors>python -c "import pvfactors"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "C:\Users\KANDERSO\projects\pvfactors\pvfactors\__init__.py", line 21, in <module>
    raise err
  File "C:\Users\KANDERSO\projects\pvfactors\pvfactors\__init__.py", line 8, in <module>
    from shapely.geos import lgeos
  File "C:\Users\KANDERSO\Software\Anaconda3\envs\pvfactors-dev\lib\site-packages\shapely\geos.py", line 154, in <module>
    _lgeos = CDLL(os.path.join(sys.prefix, 'Library', 'bin', 'geos_c.dll'))
  File "C:\Users\KANDERSO\Software\Anaconda3\envs\pvfactors-dev\lib\ctypes\__init__.py", line 364, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: [WinError 126] The specified module could not be found; pvfactors encountered an error when importing the shapely package. This often happens when a binary dependency is missing because shapely was installed from PyPI using pip. Try reinstalling shapely from another source like conda-forge with `conda install -c conda-forge shapely`, or alternatively from Cristoph Gohlke's website if you're on Windows: https://www.lfd.uci.edu/~gohlke/pythonlibs/#shapely
```

I'm happy to push updates if this needs anything else like a changelog entry or something, let me know. 