### PR TITLE
Drop Python 2.7, 3.5, add Python 3.8 and fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
             - ~/.go_workspace
             - ~/.gradle
             - ~/.cache/bower
-      - run: pytest
+      - run: pytest -s
       - store_test_results:
           path: /tmp/circleci-test-results
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,11 @@ workflows:
   version: 2
   test:
     jobs:
-      - test-python-2.7
       - test-python-3.5
       - test-python-3.6
       - test-python-3.7
 jobs:
-  test-python-2.7: &build-template
+  test-python-3.5: &build-template
     working_directory: ~/SunPower/pvfactors
     parallelism: 1
     shell: /bin/bash --login
@@ -16,7 +15,7 @@ jobs:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     docker:
-      - image: circleci/python:2.7.14-stretch
+      - image: circleci/python:3.5.7-stretch
     steps:
       - checkout
       - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -49,10 +48,6 @@ jobs:
       - store_artifacts:
           path: build/sphinx/html
           destination: docs
-  test-python-3.5:
-    <<: *build-template
-    docker:
-      - image: circleci/python:3.5.7-stretch
   test-python-3.6:
     <<: *build-template
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,11 @@ workflows:
   version: 2
   test:
     jobs:
-      - test-python-3.5
       - test-python-3.6
       - test-python-3.7
+      - test-python-3.8
 jobs:
-  test-python-3.5: &build-template
+  test-python-3.6: &build-template
     working_directory: ~/SunPower/pvfactors
     parallelism: 1
     shell: /bin/bash --login
@@ -15,7 +15,7 @@ jobs:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     docker:
-      - image: circleci/python:3.5.7-stretch
+      - image: circleci/python:3.6.6-stretch
     steps:
       - checkout
       - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -48,11 +48,11 @@ jobs:
       - store_artifacts:
           path: build/sphinx/html
           destination: docs
-  test-python-3.6:
-    <<: *build-template
-    docker:
-      - image: circleci/python:3.6.6-stretch
   test-python-3.7:
     <<: *build-template
     docker:
       - image: circleci/python:3.7.3-stretch
+  test-python-3.8:
+    <<: *build-template
+    docker:
+      - image: circleci/python:3.8.7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
             - ~/.go_workspace
             - ~/.gradle
             - ~/.cache/bower
-      - run: pytest -s
+      - run: pytest
       - store_test_results:
           path: /tmp/circleci-test-results
       - store_artifacts:

--- a/pvfactors/tests/test_engine.py
+++ b/pvfactors/tests/test_engine.py
@@ -629,13 +629,14 @@ def test_engine_w_faoi_fn_in_irradiance_vfcalcs(params, pvmodule_canadian):
 
 def test_engine_variable_albedo(params, df_inputs_clearsky_8760):
     """Run PV engine calcs with variable albedo"""
+    n_points = 100  # limiting because circleci is taking very long
 
     irradiance_model = HybridPerezOrdered()
     pvarray = OrderedPVArray.init_from_dict(params)
     eng = PVEngine(pvarray, irradiance_model=irradiance_model)
 
     # Manage timeseries inputs
-    df_inputs = df_inputs_clearsky_8760
+    df_inputs = df_inputs_clearsky_8760[:n_points]
 
     # Get MET data
     timestamps = df_inputs.index
@@ -645,7 +646,7 @@ def test_engine_variable_albedo(params, df_inputs_clearsky_8760):
     solar_azimuth = df_inputs.solar_azimuth.values
     surface_tilt = df_inputs.surface_tilt.values
     surface_azimuth = df_inputs.surface_azimuth.values
-    albedo = np.linspace(0.01, 1, num=8760)
+    albedo = np.linspace(0.01, 1, num=n_points)
 
     # Fit engine
     eng.fit(timestamps, dni, dhi, solar_zenith, solar_azimuth,
@@ -660,7 +661,7 @@ def test_engine_variable_albedo(params, df_inputs_clearsky_8760):
     bfg_after_aoi = (np.nansum(pvrow.back.get_param_weighted('qabs'))
                      / np.nansum(pvrow.front.get_param_weighted('qabs'))
                      ) * 100.
-    expected_bfg = 16.608263
-    expected_bfg_after_aoi = 16.272742
+    expected_bfg = 14.973198
+    expected_bfg_after_aoi = 14.670709
     np.testing.assert_allclose(bfg, expected_bfg)
     np.testing.assert_allclose(bfg_after_aoi, expected_bfg_after_aoi)

--- a/pvfactors/tests/test_engine.py
+++ b/pvfactors/tests/test_engine.py
@@ -6,6 +6,7 @@ from pvfactors.viewfactors.aoimethods import faoi_fn_from_pvlib_sandia
 from pvfactors.viewfactors.calculator import VFCalculator
 import numpy as np
 import datetime as dt
+import pytest
 
 
 def test_pvengine_float_inputs_iso(params):
@@ -625,7 +626,7 @@ def test_engine_w_faoi_fn_in_irradiance_vfcalcs(params, pvmodule_canadian):
         pvarray.ts_pvrows[1].back.get_param_weighted('qabs'),
         [114.2143503])
 
-
+@pytest.mark.skip("disable test to see if responsible for circleci hanging")
 def test_engine_variable_albedo(params, df_inputs_clearsky_8760):
     """Run PV engine calcs with variable albedo"""
 

--- a/pvfactors/tests/test_engine.py
+++ b/pvfactors/tests/test_engine.py
@@ -626,7 +626,7 @@ def test_engine_w_faoi_fn_in_irradiance_vfcalcs(params, pvmodule_canadian):
         pvarray.ts_pvrows[1].back.get_param_weighted('qabs'),
         [114.2143503])
 
-@pytest.mark.skip("disable test to see if responsible for circleci hanging")
+
 def test_engine_variable_albedo(params, df_inputs_clearsky_8760):
     """Run PV engine calcs with variable albedo"""
 
@@ -645,7 +645,7 @@ def test_engine_variable_albedo(params, df_inputs_clearsky_8760):
     solar_azimuth = df_inputs.solar_azimuth.values
     surface_tilt = df_inputs.surface_tilt.values
     surface_azimuth = df_inputs.surface_azimuth.values
-    albedo = np.linspace(0, 1, num=8760)
+    albedo = np.linspace(0.01, 1, num=8760)
 
     # Fit engine
     eng.fit(timestamps, dni, dhi, solar_zenith, solar_azimuth,
@@ -660,7 +660,7 @@ def test_engine_variable_albedo(params, df_inputs_clearsky_8760):
     bfg_after_aoi = (np.nansum(pvrow.back.get_param_weighted('qabs'))
                      / np.nansum(pvrow.front.get_param_weighted('qabs'))
                      ) * 100.
-    expected_bfg = 16.441664
-    expected_bfg_after_aoi = 16.109509
+    expected_bfg = 16.608263
+    expected_bfg_after_aoi = 16.272742
     np.testing.assert_allclose(bfg, expected_bfg)
     np.testing.assert_allclose(bfg_after_aoi, expected_bfg_after_aoi)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pvlib>=0.6.0
+pvlib>=0.6.0,<0.8.0
 shapely>=1.6.4.post2
 matplotlib
 future


### PR DESCRIPTION
Closes #111 
Closes #107

- drop support for python 2.7 & 3.5
- restrict pvlib version to >=0.6.0,<0.8.0 (0.8.0 broke the API) until have time to update implementation
- fix CI tests: tests were randomly hanging at a particular test in `test_engine.py`, was probably due to full simulation that was too much for CI instance, so reduced number of points