### PR TITLE
Updates for pvlib 0.8.0

### DIFF
--- a/docs/sphinx/whatsnew.rst
+++ b/docs/sphinx/whatsnew.rst
@@ -6,6 +6,7 @@ What's New
 
 These are new features and improvements of note in each release.
 
+.. include:: whatsnew/v1.5.1.rst
 .. include:: whatsnew/v1.5.0.rst
 .. include:: whatsnew/v1.4.1.rst
 .. include:: whatsnew/v1.4.0.rst

--- a/docs/sphinx/whatsnew/v1.5.1.rst
+++ b/docs/sphinx/whatsnew/v1.5.1.rst
@@ -1,0 +1,12 @@
+.. _whatsnew_151:
+
+v1.5.1 (DATE XX, 2021)
+======================
+
+Update pvlib dependency from ``pvlib>=0.6.0,<0.8.0`` to ``pvlib>=0.7.0,<0.9.0`` (:ghpull:`116`)
+
+
+Contributors
+------------
+* Marc Anoma (:ghuser:`anomam`)
+* Kevin Anderson (:ghuser:`kanderso-nrel`)

--- a/pvfactors/viewfactors/aoimethods.py
+++ b/pvfactors/viewfactors/aoimethods.py
@@ -681,6 +681,6 @@ def faoi_fn_from_pvlib_sandia(pvmodule_name):
         # Transform the inputs for the SAPM function
         angles = np.where(angles >= 90, angles - 90, 90. - angles)
         # Use pvlib sapm aoi loss method
-        return pvlib.pvsystem.sapm_aoi_loss(angles, pvmodule, upper=1.)
+        return pvlib.iam.sapm(angles, pvmodule, upper=1.)
 
     return fn

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pvlib>=0.6.0,<0.8.0
+pvlib>=0.7.0,<0.9.0
 shapely>=1.6.4.post2
 matplotlib
 future


### PR DESCRIPTION
Closes #114 

Turned out to be easier than I expected; only one change was needed (pvsystem.sapm_aoi_loss -> iam.sapm).

Tests pass for me locally for each of pvlib==[0.7.0, 0.7.1, 0.7.2, 0.8.0, 0.8.1, 0.9.0a6].  Not sure when 0.9.0 is coming out, so I think to be safe better keep `<0.9.0` for now.  Note that running the test suite did spawn several plot windows that I wasn't sure how to check.

Would it be helpful to create a v1.6.0 (?) whatsnew file in this PR, or do you want to do that separately?

Edit: maybe CircleCI isn't running because I'm opening this from an untrusted fork?  I'm not familiar with CircleCI but I've seen that with other CI providers so that random people can't open a PR and access sensitive info with `print(secret_api_key)` in a test function.  Let me know if there's something I can do on my end to get the CI to check this. 