### PR TITLE
Updates for pvlib 0.9.0

### DIFF
--- a/docs/sphinx/tutorials/index.rst
+++ b/docs/sphinx/tutorials/index.rst
@@ -49,7 +49,7 @@ In the "full mode", ``pvfactors`` calculates the equilibrium of reflections betw
 Details on the "fast mode" simulations
 ======================================
 
-In the "fast mode", ``pvfactors`` assumes that all incident irradiance values for the system are known except for the PV row back surfaces. So since the system to solve is now explicit (no matrix inversion needed), it runs a little bit faster than the full mode, but it is less acurrate.
+In the "fast mode", ``pvfactors`` assumes that all incident irradiance values for the system are known except for the PV row back surfaces. So since the system to solve is now explicit (no matrix inversion needed), it runs a little bit faster than the full mode, but it is less accurate.
 
 .. note::
    Some tests show that for 8760 hourly simulations, the run time is less than 1 second for the fast mode vs. less than 2 seconds for the full mode.

--- a/docs/sphinx/whatsnew.rst
+++ b/docs/sphinx/whatsnew.rst
@@ -6,6 +6,7 @@ What's New
 
 These are new features and improvements of note in each release.
 
+.. include:: whatsnew/v1.5.2.rst
 .. include:: whatsnew/v1.5.1.rst
 .. include:: whatsnew/v1.5.0.rst
 .. include:: whatsnew/v1.4.1.rst

--- a/docs/sphinx/whatsnew/v1.5.2.rst
+++ b/docs/sphinx/whatsnew/v1.5.2.rst
@@ -1,0 +1,15 @@
+.. _whatsnew_152:
+
+v1.5.2 (DATE XX, 2021)
+======================
+
+Enhancements
+------------
+
+* Update pvlib dependency from ``pvlib>=0.7.0,<0.9.0`` to ``pvlib>=0.7.0,<0.10.0`` (:ghpull:`121`)
+
+
+Contributors
+------------
+* Marc Anoma (:ghuser:`anomam`)
+* Kevin Anderson (:ghuser:`kanderso-nrel`)

--- a/pvfactors/tests/test_engine.py
+++ b/pvfactors/tests/test_engine.py
@@ -555,7 +555,7 @@ def test_check_direct_shading_continuity():
 
     # Check expected outputs: before v1.3.0, expected output is
     # [20.4971271991293, 21.389095477613356], which shows discontinuity
-    expected_out = [20.497127, 20.50229]
+    expected_out = [20.936348, 20.942163]
     np.testing.assert_allclose(out, expected_out)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pvlib>=0.7.0,<0.9.0
+pvlib>=0.7.0,<0.10.0
 shapely>=1.6.4.post2
 matplotlib
 future


### PR DESCRIPTION
Howdy @anomam, pvlib 0.9.0 was released the other day.  No changes needed in pvfactors itself, but there is one change needed to the test suite related to a bugfix in the Perez model (https://github.com/pvlib/pvlib-python/pull/1239).  I have updated the values here to pass with pvlib 0.9.0, but that means the test fails on older pvlib versions.  Is that acceptable?  I could make the test values depend on the installed pvlib version if you want the tests to pass with older pvlibs as well.  I suspect CircleCI will install the latest pvlib for this PR, but we'll see what actually happens.

I also took the liberty of creating a 1.5.2 whatsnew, although a note about different irradiance values w/ pvlib 0.9.0 may be in order.

Unrelated: may want to add python 3.9 to the test matrix -- 3.10 release candidates are already available on some CIs!

cc @spaneja