### PR TITLE
Update documented python version support; add py3.9 test configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ workflows:
       - test-python-3.6
       - test-python-3.7
       - test-python-3.8
+      - test-python-3.9
 jobs:
   test-python-3.6: &build-template
     working_directory: ~/SunPower/pvfactors
@@ -56,3 +57,7 @@ jobs:
     <<: *build-template
     docker:
       - image: circleci/python:3.8.7
+  test-python-3.9:
+    <<: *build-template
+    docker:
+      - image: circleci/python:3.9.7-buster

--- a/README.rst
+++ b/README.rst
@@ -165,7 +165,7 @@ The users can also create a "report" while running the simulations that will rel
 Installation
 ------------
 
-pvfactors is currently compatible and tested with Python 2 and 3, and is available in `PyPI <https://pypi.org/project/pvfactors/>`_. The easiest way to install pvfactors is to use pip_ as follows:
+pvfactors is currently compatible and tested with 3.6+, and is available in `PyPI <https://pypi.org/project/pvfactors/>`_. The easiest way to install pvfactors is to use pip_ as follows:
 
 .. code:: sh
 

--- a/docs/sphinx/installation/index.rst
+++ b/docs/sphinx/installation/index.rst
@@ -7,7 +7,7 @@ Installation
 Install with pip
 ----------------
 
-``pvfactors`` works with both python 2 and 3.
+``pvfactors`` currently supports python 3.6+.
 
 The easiest way to install ``pvfactors`` is using pip_:
 

--- a/setup.py
+++ b/setup.py
@@ -24,10 +24,9 @@ CLASSIFIERS = [
     'Operating System :: OS Independent',
     'Intended Audience :: Science/Research',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 2.7',
-    'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
     'Topic :: Scientific/Engineering',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
     'Topic :: Scientific/Engineering',
 ]
 


### PR DESCRIPTION
I noticed a few places in the docs that mentioned older python versions that are no longer supported as of #112 and updated them here.  I think the PyPI badge in the readme will automatically update once the changes to `setup.py` are propagated to `pypi.org`.  I also added a python 3.9 test configuration.  

I assume the tests will fail because of the same sphinx issue in #121 so I'm marking this as draft and will merge master in after #121 is complete :)

Side notes:

1) Looks like the docs on `gh-pages` are still for 1.5.0 and could use a rebuild for 1.5.1
2) I don't think this is a pressing issue (though I have almost no experience w/ CircleCI so maybe I'm wrong), just FYI: the docker images used in pvfactor's CI config are apparently considered "legacy" and these new images should be preferred: https://circleci.com/developer/images/image/cimg/python  