### PR TITLE
Restrict shapely dependency to <=2

### DIFF
--- a/docs/sphinx/whatsnew/v1.5.2.rst
+++ b/docs/sphinx/whatsnew/v1.5.2.rst
@@ -3,10 +3,14 @@
 v1.5.2 (DATE XX, 2021)
 ======================
 
-Enhancements
+Requirements
 ------------
 
 * Add python 3.9 to test configuration (:ghpull:`122`)
+* Set the upper bound on shapely to version 1.7.1 (released Aug 20, 2020)
+  to suppress deprecation warnings.  The shapely dependency may be dropped
+  altogether in a future pvfactors release.  (:ghpull:`130`)
+
 
 Fixes
 -----

--- a/docs/sphinx/whatsnew/v1.5.2.rst
+++ b/docs/sphinx/whatsnew/v1.5.2.rst
@@ -7,8 +7,8 @@ Requirements
 ------------
 
 * Add python 3.9 to test configuration (:ghpull:`122`)
-* Set the upper bound on shapely to version 1.7.1 (released Aug 20, 2020)
-  to suppress deprecation warnings.  The shapely dependency may be dropped
+* Set the upper bound on shapely to version 2.0 (not yet released).
+  The shapely dependency may be dropped
   altogether in a future pvfactors release.  (:ghpull:`130`)
 
 

--- a/pvfactors/tests/test_engine.py
+++ b/pvfactors/tests/test_engine.py
@@ -652,21 +652,21 @@ def test_engine_w_faoi_fn_in_irradiance_vfcalcs(params, pvmodule_canadian):
     # Run timestep
     pvarray = eng.run_full_mode(fn_build_report=lambda pvarray: pvarray)
     # Checks
-    np.testing.assert_almost_equal(
+    np.testing.assert_allclose(
         pvarray.ts_pvrows[0].front.get_param_weighted('qinc'),
         1110.1164773159298)
-    np.testing.assert_almost_equal(
+    np.testing.assert_allclose(
         pvarray.ts_pvrows[1].front.get_param_weighted('qinc'), 1110.595903991)
-    np.testing.assert_almost_equal(
+    np.testing.assert_allclose(
         pvarray.ts_pvrows[2].front.get_param_weighted('qinc'), 1112.37717553)
-    np.testing.assert_almost_equal(
+    np.testing.assert_allclose(
         pvarray.ts_pvrows[1].back.get_param_weighted('qinc'),
         116.49050349491208)
     # Check absorbed irradiance: calculated using faoi functions
-    np.testing.assert_almost_equal(
+    np.testing.assert_allclose(
         pvarray.ts_pvrows[2].front.get_param_weighted('qabs'),
-        [1109.1180884])
-    np.testing.assert_almost_equal(
+        [1109.1180884], rtol=1e-6)
+    np.testing.assert_allclose(
         pvarray.ts_pvrows[1].back.get_param_weighted('qabs'),
         [114.2143503])
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pvlib>=0.9.0,<0.10.0
-shapely>=1.6.4.post2
+shapely>=1.6.4.post2,<=1.7.1
 matplotlib
 future
 six

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pvlib>=0.9.0,<0.10.0
-shapely>=1.6.4.post2,<=1.7.1
+shapely>=1.6.4.post2,<2
 matplotlib
 future
 six


### PR DESCRIPTION
Closes #126.

I wonder if we should think about releasing 1.5.2 soon?  Besides these deprecation warnings and the `tilt=0` issue from #125, it would be nice for the latest pvfactors version to allow pvlib==0.9.0 on installation.  Someone asked about this on the pvlib google group: https://groups.google.com/g/pvlib-python/c/hNaNsM1pNSw