### PR TITLE
Improve runtime and peak memory usage of PVEngine.run_full_mode

### DIFF
--- a/docs/sphinx/whatsnew/v1.5.3.rst
+++ b/docs/sphinx/whatsnew/v1.5.3.rst
@@ -6,11 +6,16 @@ v1.5.3 (TBD)
 Enhancements
 ------------
 
-* Add python3.10 to test configuration (ghpull:`129`)
+* Add python 3.10 to test configuration (:ghpull:`129`)
+* :py:meth:`pvfactors.engine.PVEngine.run_full_mode` is faster and uses less
+  memory for simulations with large ``n_pvrows`` and many timestamps (:ghpull:`140`)
 
 
 Requirements
 ------------
+
+* ``scipy>=1.2.0`` is now a direct requirement (before now it was only
+  indirectly required through pvlib) (:ghpull:`140`)
 
 
 Bug Fixes

--- a/pvfactors/engine.py
+++ b/pvfactors/engine.py
@@ -9,14 +9,41 @@ from pvfactors.irradiance import HybridPerezOrdered
 from pvfactors.config import DEFAULT_RHO_FRONT, DEFAULT_RHO_BACK
 
 
-def _sparse_solve(A, b):
+def _sparse_solve_3D(A, b):
+    """
+    Solve the linear system A*x=b for x, where A is sparse (contains mostly
+    zeros).
+
+    For large matrices with many zeros, this is faster and uses less memory
+    than the dense analog `np.linalg.solve`.
+
+    Parameters
+    ----------
+    A : np.ndarray of shape (M, N, N)
+        First dimension is timestamps, second and third are surface dimensions
+    b : np.ndarray of shape (M, N)
+        First dimension is timestamps, second is surfaces
+
+    Returns
+    -------
+    x : np.ndarray of shape (M, N)
+        First dimension is timestamps, second is surfaces
+    """
+    # implementation notes:
+    # - csc_matrix seemed to be the fastest option of the various
+    #   sparse matrix formats in scipy.sparse
+    # - unfortunately the sparse matrix formats are 2-D only, so
+    #   iteration across the time dimension is required
+    # - scipy 1.8.0 added new sparse arrays (as opposed to sparse matrices);
+    #   they are 2-D only at time of writing, but in the future if they
+    #   become N-D then it may make sense to use them here.
     xs = []
-    for A_slice, b_slice in zip(A, b.T):
+    for A_slice, b_slice in zip(A, b):
         A_sparse = csc_matrix(A_slice)
         b_sparse = csc_matrix(b_slice).T
         x = spsolve(A_sparse, b_sparse)
         xs.append(x)
-    x = np.stack(xs).T
+    x = np.stack(xs)
     return x
 
 
@@ -234,7 +261,7 @@ class PVEngine(object):
         a_mat = invrho_ts_diag - ts_vf_matrix_reshaped
         del ts_vf_matrix_reshaped
         # solve the linear system a_mat * q0 = irradiance_mat for q0
-        q0 = _sparse_solve(a_mat, irradiance_mat)
+        q0 = _sparse_solve_3D(a_mat, irradiance_mat.T).T
         del a_mat
         # Calculate incident irradiance: will rely on broadcasting
         # shape = n_surfaces + 1, n_timesteps

--- a/pvfactors/engine.py
+++ b/pvfactors/engine.py
@@ -39,6 +39,10 @@ def _sparse_solve_3D(A: np.ndarray, b: np.ndarray) -> np.ndarray:
       they are 2-D only at time of writing, but in the future if they
       become N-D then it may make sense to use them here.
     """
+    if b.size == 0:
+        # prevent ValueError from np.stack call below.
+        # it's empty, so values don't matter -- just shape (and dtype?)
+        return np.zeros_like(b)
     xs = []
     for A_slice, b_slice in zip(A, b):
         A_sparse = csc_matrix(A_slice)

--- a/pvfactors/tests/test_engine.py
+++ b/pvfactors/tests/test_engine.py
@@ -1,4 +1,4 @@
-from pvfactors.engine import PVEngine
+from pvfactors.engine import PVEngine, _sparse_solve_3D
 from pvfactors.geometry.pvarray import OrderedPVArray
 from pvfactors.irradiance import IsotropicOrdered, HybridPerezOrdered
 from pvfactors.irradiance.utils import breakup_df_inputs
@@ -709,3 +709,13 @@ def test_engine_variable_albedo(params, df_inputs_clearsky_8760):
     expected_bfg_after_aoi = 14.670709
     np.testing.assert_allclose(bfg, expected_bfg)
     np.testing.assert_allclose(bfg_after_aoi, expected_bfg_after_aoi)
+
+
+def test__sparse_solve_3d():
+    """Verify the sparse solver returns same results as np.linalg.solve"""
+    A = np.random.rand(5, 3, 3)
+    b = np.random.rand(5, 3)
+    x_dense = np.linalg.solve(A, b)
+    x_sparse = _sparse_solve_3D(A, b)
+    assert x_sparse.shape == b.shape
+    np.testing.assert_allclose(x_dense, x_sparse)

--- a/pvfactors/tests/test_engine.py
+++ b/pvfactors/tests/test_engine.py
@@ -719,3 +719,26 @@ def test__sparse_solve_3d():
     x_sparse = _sparse_solve_3D(A, b)
     assert x_sparse.shape == b.shape
     np.testing.assert_allclose(x_dense, x_sparse)
+
+
+def test_engine_empty_inputs(params, df_inputs_clearsky_8760):
+    """Empty inputs yields empty outputs"""
+    df_inputs = df_inputs_clearsky_8760.iloc[:0]
+    timestamps = df_inputs.index
+    dni = df_inputs.dni.values
+    dhi = df_inputs.dhi.values
+    solar_zenith = df_inputs.solar_zenith.values
+    solar_azimuth = df_inputs.solar_azimuth.values
+    surface_tilt = df_inputs.surface_tilt.values
+    surface_azimuth = df_inputs.surface_azimuth.values
+
+    # Run engine
+    pvarray = OrderedPVArray.init_from_dict(params)
+    eng = PVEngine(pvarray)
+    eng.fit(timestamps, dni, dhi, solar_zenith, solar_azimuth, surface_tilt,
+            surface_azimuth, params['rho_ground'])
+    qinc = eng.run_full_mode(
+        fn_build_report=lambda pvarray: (pvarray.ts_pvrows[1]
+                                         .back.get_param_weighted('qinc')))
+
+    assert len(qinc) == 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pvlib>=0.9.0,<0.10.0
 shapely>=1.6.4.post2,<2
+scipy>=1.2.0
 matplotlib
 future
 six


### PR DESCRIPTION
This PR does two things:
1) As discussed in #134, the majority of the runtime of `PVEngine.run_full_mode` is in the matrix inversion.  However, especially for large simulations, using a sparse linear solve function turns out to be significantly faster than explicitly inverting the full matrix. This replaces the linear algebra operations from `numpy.linalg` with sparse equivalents from `scipy.sparse.linalg`.
2) `PVEngine.run_full_mode` creates many large matrices, most of which are only needed in certain parts of the function.  This results in significant (GBs) memory usage for large simulations.  Especially for large simulations, including `del` statements when these large matrices are no longer needed reduces maximum memory usage significantly. 


Here are some runtime and peak memory comparisons of a typical call to the pvlib wrapper function (`pvlib.bifacial.pvfactors_timeseries` in v0.9.0).  All values are the ratio of this PR to v1.5.2, so e.g. a value of 0.67 means this PR runs in 2/3 the time, or uses 2/3 the memory, relative to v1.5.2.

Runtime ratio:
```
n_timestamps  100    1000   5000   10000
n_pvrows                                
3              0.91   0.77   0.81   0.80
5              0.61   0.41   0.31   0.39
7              0.60   0.40   0.30   0.34
```

Peak RAM usage ratio:
```
n_timestamps  100    1000   5000   10000
n_pvrows                                
3              0.99   0.84   0.67   0.63
5              0.97   0.67   0.60   0.59
7              0.75   0.61   0.58   0.58
```

The above ratios, especially the peak memory values, are relatively stable on my machine.  Timing is rather less stable; reducing external CPU load as much as possible and setting the power mode to "best battery" (in an attempt to disable CPU turbo boost and such) seems to help.  I would be very interested to see if others can recreate the above results, especially on the timing side -- @spaneja kindly ran some for me earlier and the results were not wholly consistent with what I've shown above.  

Miscellaneous to-do:
- [x] take a closer look at where memory is allocated and where it is used; the current `del` situation is probably still suboptimal
- [x] what's new
- [x] tests?
- [x] make scipy an explicit dependency (right now it's implicit via pvlib)
- [x] document `_sparse_solve`
- [ ] ...and maybe put it somewhere that makes more sense?
- [ ] consider making the sparse approach opt-in via a boolean kwarg or similar?